### PR TITLE
Fix Bedrock IAM policy for inference profiles

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -53,17 +53,20 @@ if ! aws iam get-role --role-name "${ROLE_NAME}" &>/dev/null; then
   aws iam put-role-policy \
     --role-name "${ROLE_NAME}" \
     --policy-name BedrockInvokeModel \
-    --policy-document '{
-      "Version": "2012-10-17",
-      "Statement": [{
-        "Effect": "Allow",
-        "Action": [
-          "bedrock:InvokeModel",
-          "bedrock:InvokeModelWithResponseStream"
+    --policy-document "{
+      \"Version\": \"2012-10-17\",
+      \"Statement\": [{
+        \"Effect\": \"Allow\",
+        \"Action\": [
+          \"bedrock:InvokeModel\",
+          \"bedrock:InvokeModelWithResponseStream\"
         ],
-        "Resource": "arn:aws:bedrock:*::foundation-model/*"
+        \"Resource\": [
+          \"arn:aws:bedrock:*::foundation-model/*\",
+          \"arn:aws:bedrock:*:${ACCOUNT_ID}:inference-profile/*\"
+        ]
       }]
-    }'
+    }"
 
   aws iam put-role-policy \
     --role-name "${ROLE_NAME}" \


### PR DESCRIPTION
## Summary

- Add `inference-profile/*` resource to `BedrockInvokeModel` IAM policy in `deploy.sh`
- Cross-region model IDs (`us.anthropic.*`) resolve to inference-profile ARNs, not foundation-model ARNs — this was the root cause of 500s on invocation

## Test plan

- [x] Live invocation returns recipe JSON after policy fix
- [ ] Deploy workflow succeeds on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)