### PR TITLE
docs: add 9-part deployment guide for Bedrock AgentCore

### DIFF
--- a/docs/deployment-guide/01-introduction-and-prerequisites.md
+++ b/docs/deployment-guide/01-introduction-and-prerequisites.md
@@ -1,0 +1,250 @@
+# Part 1: Introduction & Prerequisites
+
+[<- Back to Index](./README.md) | [Next: Agent Architecture ->](./02-agent-architecture-deep-dive.md)
+
+---
+
+## What is an AI Agent?
+
+An AI agent is software that uses a large language model (LLM) as its reasoning engine. Unlike a simple chat interface, an agent can:
+
+- **Use tools** — call functions (HTTP requests, database queries, file operations) to interact with the world
+- **Make decisions** — the LLM decides *which* tools to call, *when*, and *how to interpret* results
+- **Follow multi-step plans** — chain tool calls together to accomplish complex tasks
+
+The pattern looks like this:
+
+```
+User request
+  → LLM reads request + system prompt
+    → LLM decides to call a tool
+      → Tool executes, returns result
+        → LLM reads result, decides next step
+          → ... (loop until done)
+            → LLM produces final answer
+```
+
+The framework that orchestrates this loop is called an **agent framework**. This project uses the [Strands Agents SDK](https://github.com/strands-agents/sdk-typescript) (`@strands-agents/sdk`) — it handles the tool-use loop, manages conversation state, and communicates with Amazon Bedrock's Converse API.
+
+## What is Amazon Bedrock AgentCore?
+
+[Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) is an AWS service that runs your agent as a managed container with:
+
+- **VM-level isolation** — each agent runtime gets its own compute environment
+- **Built-in HTTP server** — a Fastify server on port 8080 with standard endpoints
+- **Managed lifecycle** — AWS handles scaling, health checks, and networking
+- **AWS IAM integration** — the container assumes an IAM execution role for Bedrock, Secrets Manager, etc.
+
+Your agent container exposes two endpoints:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/ping` | GET | Health check (returns `"pong"`) |
+| `/invocations` | POST | Agent invocation (your handler) |
+
+AgentCore handles TLS, load balancing, and routing. You write a handler, package it in a Docker container, and deploy.
+
+## What This Project Builds
+
+The **recipe-extraction-agent** takes a URL, fetches the webpage, and returns structured recipe data as JSON:
+
+```
+POST /invocations
+{"url": "https://pinchofyum.com/chicken-wontons-in-spicy-chili-sauce"}
+
+→ Returns:
+{
+  "title": "Chicken Wontons in Spicy Chili Sauce",
+  "ingredients": [
+    {"quantity": 1, "unit": "lb", "name": "ground chicken", "description": ""},
+    ...
+  ],
+  "preparationSteps": ["Mix filling ingredients...", ...],
+  "cookingSteps": ["Boil wontons for 4 minutes...", ...],
+  "notes": {
+    "servings": "4 servings",
+    "cookTime": "10 minutes",
+    "prepTime": "30 minutes"
+  }
+}
+```
+
+The agent uses Claude Haiku 4.5 on Bedrock, a custom `fetch_url` tool that extracts text and JSON-LD data from recipe pages, and Zod schemas for response validation.
+
+## Architecture Overview
+
+```mermaid
+graph LR
+    Client([Client]) -->|POST /invocations| AgentCore
+    AgentCore -->|AIRS pre-scan| AIRS([Prisma AIRS])
+    AgentCore -->|agent.invoke| Agent
+    Agent -->|Converse API| Bedrock([Amazon Bedrock])
+    Agent -->|fetch_url| Web([Recipe Website])
+    AgentCore -->|AIRS post-scan| AIRS
+    AgentCore -->|Recipe JSON| Client
+```
+
+The full request flow:
+1. Client POSTs a URL to `/invocations`
+2. Prisma AIRS scans the prompt for security threats (optional)
+3. Strands Agent invokes Claude Haiku 4.5 via Bedrock
+4. LLM calls `fetch_url` to retrieve the webpage
+5. LLM extracts recipe data from the page content
+6. `extractJson()` parses the LLM text output
+7. `RecipeSchema.parse()` validates the JSON against Zod schemas
+8. Prisma AIRS scans the response (optional)
+9. Validated recipe JSON is returned to the client
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+| Tool | Version | Purpose |
+|---|---|---|
+| **Node.js** | 20+ | Runtime |
+| **npm** | 10+ | Package manager (ships with Node) |
+| **AWS CLI** | v2 | AWS resource management |
+| **Docker Desktop** | Latest | Container builds |
+| **Git** | Latest | Version control |
+
+**AWS account requirements:**
+- An AWS account with Bedrock model access enabled for **Claude Haiku 4.5** in `us-west-2`
+- IAM permissions to create roles, ECR repositories, and Secrets Manager secrets
+- (For CI/CD) A GitHub account with a fork/clone of this repository
+
+### Verify your tools
+
+```bash
+node --version    # v20.x or higher
+npm --version     # 10.x or higher
+aws --version     # aws-cli/2.x
+docker --version  # Docker version 2x.x
+```
+
+### Enable Bedrock model access
+
+1. Open the [Amazon Bedrock console](https://console.aws.amazon.com/bedrock/) in `us-west-2`
+2. Go to **Model access** in the left sidebar
+3. Enable access to **Anthropic → Claude Haiku 4.5**
+4. Wait for the status to show "Access granted"
+
+## Local Setup
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/cdot65/aws-bedrock-agentcore-typescript-example.git
+cd aws-bedrock-agentcore-typescript-example
+npm install
+```
+
+The `prepare` script automatically configures git to use the project's pre-commit hooks:
+
+```bash
+# This runs automatically during npm install:
+git config core.hooksPath .githooks
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+The `.env.example` file:
+
+```bash
+# Prisma AIRS AI Runtime Security
+# PRISMA_AIRS_API_KEY is fetched from Secrets Manager in prod.
+# Set here for local dev only.
+PRISMA_AIRS_API_KEY=
+PRISMA_AIRS_PROFILE_NAME=
+
+# AWS Bedrock Agent metadata (optional, for AIRS agent discovery)
+BEDROCK_AGENT_ID=
+BEDROCK_AGENT_VERSION=1
+AWS_ACCOUNT_ID=
+AWS_REGION=us-west-2
+
+# AgentCore deployment (set after first deploy, used for --update)
+AGENTCORE_RUNTIME_ID=
+```
+
+For local development, the only required value is valid AWS credentials with Bedrock access. The Prisma AIRS fields are optional — the agent works without them (see [Part 3](./03-security-with-prisma-airs.md)).
+
+Ensure your AWS credentials are configured:
+
+```bash
+aws sts get-caller-identity
+```
+
+### 3. Run locally
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+This runs `tsx --env-file=.env src/main.ts` — TypeScript execution with hot reload and `.env` loading.
+
+### 4. Test the health check
+
+```bash
+curl http://localhost:8080/ping
+```
+
+Expected response:
+
+```
+"pong"
+```
+
+### 5. Test an invocation
+
+```bash
+curl -X POST http://localhost:8080/invocations \
+  -H "Content-Type: application/json" \
+  -H "x-amzn-bedrock-agentcore-runtime-session-id: test-session-1" \
+  -d '{"url": "https://pinchofyum.com/chicken-wontons-in-spicy-chili-sauce"}'
+```
+
+The response (after 5-9 seconds) will be a structured recipe JSON object:
+
+```json
+{
+  "title": "Chicken Wontons in Spicy Chili Sauce",
+  "ingredients": [
+    {
+      "quantity": 1,
+      "unit": "lb",
+      "name": "ground chicken",
+      "description": ""
+    }
+  ],
+  "preparationSteps": [
+    "Mix the ground chicken with sesame oil, soy sauce, ginger..."
+  ],
+  "cookingSteps": [
+    "Bring a large pot of water to a boil..."
+  ],
+  "notes": {
+    "servings": "4 servings",
+    "cookTime": "10 minutes",
+    "prepTime": "30 minutes"
+  }
+}
+```
+
+### 6. Run the test suite
+
+```bash
+npm test              # 71 tests
+npm run test:coverage # with coverage report
+npm run typecheck     # TypeScript type checking
+npm run check         # Biome lint + format
+```
+
+---
+
+[Next: Agent Architecture Deep Dive ->](./02-agent-architecture-deep-dive.md)

--- a/docs/deployment-guide/02-agent-architecture-deep-dive.md
+++ b/docs/deployment-guide/02-agent-architecture-deep-dive.md
@@ -1,0 +1,371 @@
+# Part 2: Agent Architecture Deep Dive
+
+[<- Back to Index](./README.md) | [Previous: Introduction](./01-introduction-and-prerequisites.md) | [Next: Security with Prisma AIRS ->](./03-security-with-prisma-airs.md)
+
+---
+
+This part walks through every layer of the agent — from the entry point through the LLM tool-use loop to response validation.
+
+## Entry Point Chain
+
+```
+src/main.ts → src/app.ts → BedrockAgentCoreApp
+```
+
+### `src/main.ts` — Bootstrap
+
+The entry point handles one concern: fetching secrets before the server starts.
+
+```typescript
+// src/main.ts
+import { GetSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+import { app } from "./app.js";
+
+async function bootstrap() {
+  if (!process.env.PRISMA_AIRS_API_KEY) {
+    try {
+      const sm = new SecretsManagerClient({
+        region: process.env.AWS_REGION || "us-west-2",
+      });
+      const secret = await sm.send(
+        new GetSecretValueCommand({
+          SecretId: "recipe-agent/prisma-airs-api-key",
+        }),
+      );
+      if (secret.SecretString) {
+        process.env.PRISMA_AIRS_API_KEY = secret.SecretString;
+      }
+    } catch {
+      console.warn("Secrets Manager unavailable, using env var for PRISMA_AIRS_API_KEY");
+    }
+  }
+  app.run();
+}
+
+bootstrap();
+```
+
+**Key points:**
+- Only fetches from Secrets Manager if the env var isn't already set (local dev uses `.env`)
+- Fails silently — if Secrets Manager is unavailable, the agent runs without AIRS
+- Calls `app.run()` to start the Fastify server on port 8080
+
+### `src/app.ts` — Agent + Server
+
+This file exports four things: `agent`, `extractJson()`, `processHandler`, and `app`. The separation makes every piece independently testable.
+
+## Model Configuration
+
+```typescript
+// src/app.ts, lines 34-39
+const model = new BedrockModel({
+  modelId: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  region: "us-west-2",
+  maxTokens: 4096,
+  temperature: 0,
+});
+```
+
+| Parameter | Value | Why |
+|---|---|---|
+| `modelId` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Fast, cheap, accurate enough for structured extraction |
+| `region` | `us-west-2` | Bedrock endpoint region |
+| `maxTokens` | `4096` | Sufficient for even large recipe JSON |
+| `temperature` | `0` | Deterministic output for consistent JSON formatting |
+
+The model ID uses a **cross-region inference profile** prefix (`us.`) which lets Bedrock route to the nearest available endpoint. The IAM role needs access to both `foundation-model/*` and `inference-profile/*` resources.
+
+## Agent + System Prompt
+
+```typescript
+// src/app.ts, lines 41-46
+export const agent = new Agent({
+  model,
+  tools: [fetchUrlTool],
+  systemPrompt: SYSTEM_PROMPT,
+  printer: false,
+});
+```
+
+The `printer: false` setting disables the SDK's built-in console output — in a server context, we use structured logging instead.
+
+The system prompt (defined at the top of `src/app.ts`) tells the LLM exactly what schema to produce:
+
+```typescript
+// src/app.ts, lines 8-32
+export const SYSTEM_PROMPT = `You are a recipe extraction agent. When given a URL:
+
+1. Use the fetch_url tool to retrieve the webpage content.
+2. Analyze the returned text and any JSON-LD data to extract the recipe.
+3. Return ONLY a valid JSON object matching this exact schema (no markdown, no explanation):
+
+{
+  "title": "string",
+  "ingredients": [
+    { "quantity": number, "unit": "string", "name": "string", "description": "string" }
+  ],
+  "preparationSteps": ["string"],
+  "cookingSteps": ["string"],
+  "notes": {
+    "servings": "string or omit",
+    "cookTime": "string or omit",
+    "prepTime": "string or omit",
+    "tips": ["string"] or omit
+  }
+}
+
+Rules:
+- quantity must be a number (convert fractions: ½=0.5, ¼=0.25, ⅓=0.33, ¾=0.75, etc.)
+- unit is empty string "" if the ingredient is unitless (e.g. "2 eggs" → unit: "")
+- description is empty string "" if no preparation notes exist
+- Separate preparation steps (no heat) from cooking steps (involving heat)
+- If JSON-LD data is available, prefer it for accuracy but verify against the page text
+- Return ONLY the JSON object, nothing else`;
+```
+
+**Design note:** The Strands SDK has a `structuredOutputSchema` parameter, but the TypeScript SDK docs state it's "not supported in TypeScript." The manual approach — system prompt instructions + `extractJson()` parsing — is reliable and fully testable.
+
+## The `fetch_url` Tool
+
+The agent has one tool: `fetch_url`. It fetches a URL, parses the HTML, and returns clean text + any JSON-LD recipe data.
+
+```typescript
+// src/tools/fetch-url.ts
+export const fetchUrlTool = tool({
+  name: "fetch_url",
+  description:
+    "Fetches a URL and returns the page text content plus any schema.org/Recipe JSON-LD data found.",
+  inputSchema: z.object({
+    url: z.url().describe("The URL to fetch"),
+  }),
+  callback: async (input) => {
+    const response = await fetch(input.url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 ...",
+        Accept: "text/html,application/xhtml+xml,...",
+        "Accept-Language": "en-US,en;q=0.9",
+      },
+      redirect: "follow",
+    });
+
+    if (!response.ok) {
+      return { text: `Error: HTTP ${response.status} ${response.statusText}`, jsonLd: null };
+    }
+
+    const html = await response.text();
+    const { document } = parseHTML(html);
+
+    // 1. Extract JSON-LD before stripping scripts
+    let jsonLd: unknown = null;
+    const ldScripts = document.querySelectorAll('script[type="application/ld+json"]');
+    for (const script of ldScripts) {
+      // Handles direct Recipe, @graph arrays, and top-level arrays
+      // ...
+    }
+
+    // 2. Strip non-content elements
+    for (const selector of STRIP_SELECTORS) {
+      for (const el of document.querySelectorAll(selector)) {
+        el.remove();
+      }
+    }
+
+    // 3. Collapse whitespace, truncate at 30k chars
+    let text = (document.body?.textContent || "").replace(/\s+/g, " ").trim();
+    if (text.length > MAX_TEXT_LENGTH) {
+      text = `${text.slice(0, MAX_TEXT_LENGTH)}... [truncated]`;
+    }
+
+    return { text, jsonLd: jsonLd ? JSON.stringify(jsonLd) : null };
+  },
+});
+```
+
+**What it does step by step:**
+
+1. **Fetches** the URL with browser-like headers (avoids bot blocking)
+2. **Extracts JSON-LD** — many recipe sites embed `schema.org/Recipe` structured data in `<script type="application/ld+json">` tags. This is high-quality structured data.
+3. **Strips noise** — removes `script`, `style`, `nav`, `header`, `footer`, `aside`, `noscript`, `iframe` elements
+4. **Extracts text** — collapses whitespace, truncates at 30,000 characters
+
+The tool returns both `text` (for the LLM to read) and `jsonLd` (structured data for accuracy). The LLM uses both to produce the final recipe JSON.
+
+**Why linkedom?** The `linkedom` package is ~200KB — jsdom is ~70MB. For server-side HTML parsing where you don't need full browser simulation, linkedom is sufficient and much lighter.
+
+## `extractJson()` — Parsing LLM Output
+
+LLMs don't always return clean JSON. They might wrap it in markdown code blocks, add explanation text, or include trailing commas. `extractJson()` handles this with a three-step fallback chain:
+
+```typescript
+// src/app.ts, lines 48-73
+export function extractJson(text: string): unknown {
+  // 1. Try direct parse
+  try {
+    return JSON.parse(text);
+  } catch { /* fall through */ }
+
+  // 2. Try markdown code block: ```json ... ```
+  const codeBlockMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  if (codeBlockMatch) {
+    try {
+      return JSON.parse(codeBlockMatch[1]);
+    } catch { /* fall through */ }
+  }
+
+  // 3. Try first { ... last }
+  const braceStart = text.indexOf("{");
+  const braceEnd = text.lastIndexOf("}");
+  if (braceStart !== -1 && braceEnd > braceStart) {
+    try {
+      return JSON.parse(text.slice(braceStart, braceEnd + 1));
+    } catch { /* fall through */ }
+  }
+
+  throw new Error("Could not extract JSON from agent response");
+}
+```
+
+This handles the three most common LLM output patterns:
+1. Clean JSON (ideal case)
+2. JSON wrapped in `` ```json ... ``` `` blocks
+3. JSON embedded in explanatory text
+
+## Zod Schemas
+
+The extracted JSON is validated against strict Zod schemas:
+
+```typescript
+// src/schemas/recipe.ts
+export const IngredientSchema = z.object({
+  quantity: z.number().describe("Numeric quantity (e.g. 2, 0.5)"),
+  unit: z.string().describe("Unit of measure. Empty string if unitless"),
+  name: z.string().describe("Ingredient name"),
+  description: z.string().describe("Preparation notes. Empty string if none"),
+});
+
+export const RecipeSchema = z.object({
+  title: z.string().describe("Recipe title"),
+  ingredients: z.array(IngredientSchema).describe("Parsed ingredient list"),
+  preparationSteps: z.array(z.string()).describe("Steps before cooking"),
+  cookingSteps: z.array(z.string()).describe("Steps involving heat"),
+  notes: z.object({
+    servings: z.string().optional(),
+    cookTime: z.string().optional(),
+    prepTime: z.string().optional(),
+    tips: z.array(z.string()).optional(),
+  }).describe("Recipe metadata and tips"),
+});
+
+export type Ingredient = z.infer<typeof IngredientSchema>;
+export type Recipe = z.infer<typeof RecipeSchema>;
+```
+
+If the LLM output doesn't match the schema, `RecipeSchema.parse()` throws with detailed error messages — this acts as a safety net against hallucinated or malformed responses.
+
+## `processHandler` — The Request Flow
+
+The handler ties everything together:
+
+```typescript
+// src/app.ts, lines 77-123
+export const processHandler = async (
+  request: { url: string },
+  context: { sessionId: string; log: { info: Function; warn: Function } },
+) => {
+  context.log.info({ url: request.url }, "Extracting recipe");
+
+  const prompt = `Extract the recipe from this URL: ${request.url}`;
+  const scanMeta = { sessionId: context.sessionId };
+
+  // 1. Pre-scan: check inbound prompt
+  if (airsClient.isEnabled()) {
+    const promptScan = await airsClient.scanPrompt(prompt, scanMeta);
+    if (promptScan?.action === "block") {
+      return { error: "blocked", message: "Request blocked by Prisma AIRS security.", ... };
+    }
+  }
+
+  // 2. Invoke the agent
+  const result: AgentResult = await agent.invoke(prompt);
+
+  // 3. Parse + validate
+  const responseText = result.toString();
+  const parsed = extractJson(responseText);
+  const recipe = RecipeSchema.parse(parsed);
+
+  // 4. Post-scan: check outbound response
+  if (airsClient.isEnabled()) {
+    const responseScan = await airsClient.scanResponse(JSON.stringify(recipe), prompt, scanMeta);
+    if (responseScan?.action === "block") {
+      return { error: "blocked", message: "Response blocked by Prisma AIRS security.", ... };
+    }
+  }
+
+  return recipe;
+};
+```
+
+## BedrockAgentCoreApp Wiring
+
+Finally, the app is created and exported:
+
+```typescript
+// src/app.ts, lines 146-155
+export const app = new BedrockAgentCoreApp({
+  config: { logging: { options: { stream: logStream } } },
+  invocationHandler: {
+    requestSchema: z.object({
+      url: z.string().url().describe("URL of the recipe page to extract"),
+    }),
+    process: processHandler,
+  },
+});
+```
+
+- `requestSchema` validates incoming POST bodies — rejects anything without a valid URL
+- `process` is called for every `/invocations` request
+- `config.logging.options.stream` routes Pino logs to stdout + CloudWatch (see [Part 4](./04-observability-cloudwatch-logs.md))
+
+## Request Flow Sequence
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant App as BedrockAgentCoreApp
+    participant AIRS as Prisma AIRS
+    participant A as Strands Agent
+    participant B as Amazon Bedrock
+    participant T as fetch_url Tool
+    participant W as Recipe Website
+
+    C->>+App: POST /invocations {"url": "..."}
+    Note over App: Zod validates request
+
+    App->>+AIRS: scanPrompt(prompt)
+    AIRS-->>-App: {action: "allow"}
+
+    App->>+A: agent.invoke("Extract recipe from URL")
+    A->>+B: Converse API (system prompt + user message)
+    B-->>-A: tool_use: fetch_url({url})
+
+    A->>+T: fetch_url({url})
+    T->>+W: GET https://...
+    W-->>-T: HTML
+    Note over T: Parse HTML, extract JSON-LD,<br/>strip noise, truncate at 30k
+    T-->>-A: {text, jsonLd}
+
+    A->>+B: Converse API (tool result)
+    B-->>-A: Recipe JSON text
+    A-->>-App: AgentResult
+
+    Note over App: extractJson() → RecipeSchema.parse()
+
+    App->>+AIRS: scanResponse(recipe, prompt)
+    AIRS-->>-App: {action: "allow"}
+
+    App-->>-C: 200 OK — Recipe JSON
+```
+
+---
+
+[Next: Security with Prisma AIRS ->](./03-security-with-prisma-airs.md)

--- a/docs/deployment-guide/03-security-with-prisma-airs.md
+++ b/docs/deployment-guide/03-security-with-prisma-airs.md
@@ -1,0 +1,300 @@
+# Part 3: Security with Prisma AIRS
+
+[<- Back to Index](./README.md) | [Previous: Architecture](./02-agent-architecture-deep-dive.md) | [Next: Observability ->](./04-observability-cloudwatch-logs.md)
+
+---
+
+## Why AI Runtime Security?
+
+AI agents introduce a new class of security risks that traditional WAFs and API gateways don't cover:
+
+| Threat | Description |
+|---|---|
+| **Prompt injection** | Malicious input that tricks the LLM into ignoring its instructions |
+| **Data exfiltration** | Prompts designed to extract training data or system prompts |
+| **Toxic content** | LLM generates harmful, offensive, or inappropriate output |
+| **DLP violations** | Sensitive data (PII, credentials) in prompts or responses |
+| **Malicious URLs** | Input URLs that point to phishing, malware, or exploit pages |
+
+These threats need to be checked **at the AI layer** — both before the prompt reaches the LLM and after the response is generated.
+
+## Prisma AIRS Overview
+
+[Prisma AIRS](https://www.paloaltonetworks.com/blog/prisma-cloud/ai-runtime-security/) (AI Runtime Security) by Palo Alto Networks provides a synchronous scan API that inspects prompts and responses in real time. It checks for:
+
+- Prompt injection attacks
+- DLP policy violations
+- Toxic/harmful content
+- Malicious URLs and code
+- Custom policy rules (configured per profile)
+
+The integration point is simple: a REST API call before and after LLM invocation.
+
+### Getting Started with Prisma AIRS
+
+1. Sign up at [Palo Alto Networks](https://www.paloaltonetworks.com/prisma/cloud) for Prisma Cloud access
+2. Navigate to **AI Runtime Security** in the Prisma Cloud console
+3. Create a security **profile** — this defines which checks are active and their thresholds
+4. Generate an **API key** for programmatic access
+
+For detailed setup instructions, refer to the [Prisma AIRS documentation](https://docs.paloaltonetworks.com/ai-runtime-security).
+
+## The PrismaAIRSClient
+
+The client lives in `src/lib/airs-api-client.ts`. It's a focused class with four public methods.
+
+### Constructor
+
+```typescript
+// src/lib/airs-api-client.ts
+export class PrismaAIRSClient {
+  private readonly apiUrl: string;
+  private readonly apiKey: string;
+  private readonly profileName: string;
+  private readonly logger: Logger;
+
+  constructor(config?: {
+    apiUrl?: string;
+    apiKey?: string;
+    profileName?: string;
+    logger?: Logger;
+  }) {
+    this.apiUrl =
+      config?.apiUrl ||
+      process.env.PRISMA_AIRS_API_URL ||
+      "https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request";
+    this.apiKey = config?.apiKey || process.env.PRISMA_AIRS_API_KEY || "";
+    this.profileName = config?.profileName || process.env.PRISMA_AIRS_PROFILE_NAME || "";
+    this.logger = config?.logger || console;
+  }
+```
+
+Configuration cascades: explicit config > env vars > defaults. The API URL defaults to the Prisma AIRS production endpoint.
+
+### `isEnabled()`
+
+```typescript
+  isEnabled(): boolean {
+    return Boolean(this.apiKey && this.profileName);
+  }
+```
+
+Returns `true` only when both API key and profile name are set. This enables **fail-open design** — if AIRS isn't configured, the agent operates normally without security scanning.
+
+### `scanPrompt()` — Pre-LLM Gate
+
+```typescript
+  async scanPrompt(
+    prompt: string,
+    metadata?: { sessionId?: string; appUser?: string },
+  ): Promise<AIRSScanResponse | null> {
+    if (!this.apiKey) return null;
+
+    const request: AIRSScanRequest = {
+      tr_id: `${Date.now()}-${randomUUID().slice(0, 8)}`,
+      session_id: metadata?.sessionId,
+      ai_profile: { profile_name: this.profileName },
+      metadata: this.buildMetadata(metadata?.appUser),
+      contents: [{ prompt }],
+    };
+
+    return this.send(request);
+  }
+```
+
+Called **before** the LLM invocation. Sends only the `prompt` field in `contents`. If AIRS returns `action: "block"`, the agent short-circuits and never calls Bedrock.
+
+### `scanResponse()` — Post-LLM Gate
+
+```typescript
+  async scanResponse(
+    response: string,
+    originalPrompt: string,
+    metadata?: { sessionId?: string; appUser?: string },
+  ): Promise<AIRSScanResponse | null> {
+    if (!this.apiKey) return null;
+
+    const request: AIRSScanRequest = {
+      tr_id: `${Date.now()}-${randomUUID().slice(0, 8)}`,
+      session_id: metadata?.sessionId,
+      ai_profile: { profile_name: this.profileName },
+      metadata: this.buildMetadata(metadata?.appUser),
+      contents: [{ prompt: originalPrompt, response }],
+    };
+
+    return this.send(request);
+  }
+```
+
+Called **after** the LLM produces output, but **before** it's returned to the client. Sends both the original prompt and the response for context-aware analysis.
+
+### `buildMetadata()` — Agent Discovery
+
+```typescript
+  private buildMetadata(appUser?: string): AIRSScanRequest["metadata"] {
+    const agentId = process.env.BEDROCK_AGENT_ID;
+    const region = process.env.AWS_REGION || "us-west-2";
+    const accountId = process.env.AWS_ACCOUNT_ID;
+
+    return {
+      app_name: "recipe-extraction-agent",
+      app_user: appUser || "anonymous",
+      ai_model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+      agent_meta: agentId
+        ? {
+            agent_id: agentId,
+            agent_version: process.env.BEDROCK_AGENT_VERSION || "1",
+            agent_arn: accountId
+              ? `arn:aws:bedrock:${region}:${accountId}:agent/${agentId}`
+              : undefined,
+          }
+        : undefined,
+    };
+  }
+```
+
+This populates AWS agent metadata in every scan request. When `BEDROCK_AGENT_ID` is set (after deployment), the AIRS dashboard can link scan results back to the specific AgentCore runtime.
+
+### `send()` — HTTP Transport
+
+```typescript
+  private async send(request: AIRSScanRequest): Promise<AIRSScanResponse | null> {
+    try {
+      const response = await fetch(this.apiUrl, {
+        method: "POST",
+        headers: {
+          "x-pan-token": this.apiKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(request),
+      });
+
+      if (!response.ok) {
+        this.logger.error(`AIRS API error: ${response.status} ${response.statusText}`);
+        return null;
+      }
+
+      return (await response.json()) as AIRSScanResponse;
+    } catch (error) {
+      this.logger.error("AIRS API request failed:", error);
+      return null;
+    }
+  }
+```
+
+**Fail-open on errors:** If the AIRS API is unreachable or returns an error, the method returns `null` and the agent continues. This prevents a third-party service outage from taking down your agent.
+
+## Integration in processHandler
+
+The AIRS checks are wired into the request handler in `src/app.ts`:
+
+```typescript
+// src/app.ts — processHandler (simplified)
+const airsClient = new PrismaAIRSClient();
+
+export const processHandler = async (request, context) => {
+  const prompt = `Extract the recipe from this URL: ${request.url}`;
+  const scanMeta = { sessionId: context.sessionId };
+
+  // PRE-SCAN: check inbound prompt
+  if (airsClient.isEnabled()) {
+    const promptScan = await airsClient.scanPrompt(prompt, scanMeta);
+    context.log.info({ action: promptScan?.action, scanId: promptScan?.scan_id }, "AIRS prompt scan");
+
+    if (promptScan?.action === "block") {
+      return {
+        error: "blocked",
+        message: "Request blocked by Prisma AIRS security.",
+        category: promptScan.category,
+        scan_id: promptScan.scan_id,
+      };
+    }
+  }
+
+  // ... agent invocation, JSON parsing, Zod validation ...
+
+  // POST-SCAN: check outbound response
+  if (airsClient.isEnabled()) {
+    const responseScan = await airsClient.scanResponse(JSON.stringify(recipe), prompt, scanMeta);
+    context.log.info({ action: responseScan?.action, scanId: responseScan?.scan_id }, "AIRS response scan");
+
+    if (responseScan?.action === "block") {
+      return {
+        error: "blocked",
+        message: "Response blocked by Prisma AIRS security.",
+        category: responseScan.category,
+        scan_id: responseScan.scan_id,
+      };
+    }
+  }
+
+  return recipe;
+};
+```
+
+### Block Response Shape
+
+When AIRS blocks a request, the agent returns:
+
+```json
+{
+  "error": "blocked",
+  "message": "Request blocked by Prisma AIRS security.",
+  "category": "prompt_injection",
+  "scan_id": "abc123-..."
+}
+```
+
+The `category` field tells the client *why* it was blocked. The `scan_id` can be used to look up details in the Prisma AIRS dashboard.
+
+## Request/Response Interfaces
+
+```typescript
+// src/lib/airs-api-client.ts
+
+export interface AIRSScanRequest {
+  tr_id: string;
+  session_id?: string;
+  ai_profile: { profile_name: string };
+  metadata?: {
+    app_name?: string;
+    app_user?: string;
+    ai_model?: string;
+    agent_meta?: {
+      agent_id?: string;
+      agent_version?: string;
+      agent_arn?: string;
+    };
+  };
+  contents: Array<{ prompt?: string; response?: string }>;
+}
+
+export interface AIRSScanResponse {
+  action: "allow" | "block";
+  category: string;
+  profile_id: string;
+  profile_name: string;
+  prompt_detected?: AIRSDetectionFlags;
+  response_detected?: AIRSDetectionFlags;
+  report_id?: string;
+  scan_id: string;
+  tr_id: string;
+}
+```
+
+## Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `PRISMA_AIRS_API_KEY` | No | API key for authentication. Fetched from Secrets Manager in prod. |
+| `PRISMA_AIRS_PROFILE_NAME` | No | Name of the AIRS security profile to use |
+| `PRISMA_AIRS_API_URL` | No | Override the default API endpoint |
+| `BEDROCK_AGENT_ID` | No | AgentCore runtime ID (set after deployment, used in metadata) |
+| `BEDROCK_AGENT_VERSION` | No | Agent version (defaults to "1") |
+| `AWS_ACCOUNT_ID` | No | Used to construct the agent ARN in metadata |
+
+All are optional. If `PRISMA_AIRS_API_KEY` and `PRISMA_AIRS_PROFILE_NAME` are not set, AIRS is completely disabled and the agent handles requests without scanning.
+
+---
+
+[Next: Observability: CloudWatch Logs ->](./04-observability-cloudwatch-logs.md)

--- a/docs/deployment-guide/04-observability-cloudwatch-logs.md
+++ b/docs/deployment-guide/04-observability-cloudwatch-logs.md
@@ -1,0 +1,232 @@
+# Part 4: Observability — CloudWatch Logs
+
+[<- Back to Index](./README.md) | [Previous: Security](./03-security-with-prisma-airs.md) | [Next: Docker Build ->](./05-docker-and-container-build.md)
+
+---
+
+## Why Custom Log Shipping?
+
+AgentCore runs your container in a VM-isolated environment, but it **doesn't automatically ship container stdout to CloudWatch**. If your agent crashes or behaves unexpectedly in production, you need logs — and you need them somewhere persistent.
+
+This project ships logs to CloudWatch Logs using a custom Writable stream that integrates with Pino (the logger built into BedrockAgentCoreApp's Fastify server).
+
+## Architecture
+
+```
+Pino logger
+  └─→ createTeeStream()
+        ├─→ process.stdout        (local visibility)
+        └─→ createCloudWatchStream()
+              ├─→ buffer (100 events or 1s)
+              └─→ PutLogEvents → CloudWatch Logs
+```
+
+Locally (`BEDROCK_AGENT_ID` not set): logs go to stdout only.
+In AgentCore (`BEDROCK_AGENT_ID` set): logs go to both stdout and CloudWatch.
+
+## The CloudWatch Stream
+
+The full implementation in `src/lib/cloudwatch-stream.ts`:
+
+```typescript
+// src/lib/cloudwatch-stream.ts
+import { hostname } from "node:os";
+import { Writable } from "node:stream";
+import {
+  CloudWatchLogsClient,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+const MAX_BATCH = 100;
+const FLUSH_INTERVAL_MS = 1_000;
+
+export function createCloudWatchStream(logGroupName: string, region: string): Writable {
+  const client = new CloudWatchLogsClient({ region });
+  const logStreamName = `${hostname()}-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  let streamCreated = false;
+  let buffer: Array<{ timestamp: number; message: string }> = [];
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  async function ensureStream() {
+    if (streamCreated) return;
+    await client.send(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+    streamCreated = true;
+  }
+
+  async function flush() {
+    if (buffer.length === 0) return;
+    const events = buffer;
+    buffer = [];
+    try {
+      await ensureStream();
+      await client.send(
+        new PutLogEventsCommand({ logGroupName, logStreamName, logEvents: events }),
+      );
+    } catch (err) {
+      process.stdout.write(`[cloudwatch-stream] flush failed: ${err}\n`);
+    }
+  }
+
+  const stream = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      const message = chunk.toString().trimEnd();
+      if (!message) return callback();
+
+      buffer.push({ timestamp: Date.now(), message });
+
+      if (!timer) {
+        timer = setInterval(() => {
+          flush();
+        }, FLUSH_INTERVAL_MS);
+        timer.unref();
+      }
+
+      if (buffer.length >= MAX_BATCH) {
+        flush().then(() => callback(), callback);
+      } else {
+        callback();
+      }
+      return true;
+    },
+    final(callback) {
+      if (timer) clearInterval(timer);
+      flush().then(() => callback(), callback);
+    },
+  });
+
+  return stream;
+}
+```
+
+### How It Works
+
+1. **Log stream naming** — Each container instance gets a unique log stream: `{hostname}-{ISO timestamp}`. This prevents conflicts when multiple instances run.
+
+2. **Lazy stream creation** — The CloudWatch log stream is created on first write (`ensureStream()`), not at startup. This avoids errors if the log group doesn't exist yet.
+
+3. **Batching** — Events are buffered and flushed when either:
+   - The buffer reaches 100 events (`MAX_BATCH`)
+   - 1 second has elapsed (`FLUSH_INTERVAL_MS`)
+
+4. **Non-blocking timer** — `timer.unref()` prevents the flush interval from keeping the process alive during shutdown.
+
+5. **Error fallback** — If CloudWatch is unreachable, errors are written to stdout and the agent continues operating.
+
+## The Tee Stream
+
+To send logs to both stdout and CloudWatch simultaneously:
+
+```typescript
+// src/lib/cloudwatch-stream.ts
+export function createTeeStream(...streams: Writable[]): Writable {
+  return new Writable({
+    write(chunk, encoding, callback) {
+      let pending = streams.length;
+      let error: Error | null = null;
+      for (const s of streams) {
+        s.write(chunk, encoding, (err) => {
+          if (err && !error) error = err;
+          if (--pending === 0) callback(error);
+        });
+      }
+      return true;
+    },
+    final(callback) {
+      let pending = streams.length;
+      let error: Error | null = null;
+      for (const s of streams) {
+        s.end((err: Error | null) => {
+          if (err && !error) error = err;
+          if (--pending === 0) callback(error);
+        });
+      }
+    },
+  });
+}
+```
+
+This writes each chunk to all streams in parallel and waits for all to complete before acknowledging.
+
+## Wiring It Up
+
+The conditional wiring in `src/app.ts`:
+
+```typescript
+// src/app.ts, lines 139-144
+const LOG_GROUP = "/aws/bedrock/agentcore/recipe-extraction-agent";
+const region = process.env.AWS_REGION || "us-west-2";
+
+const logStream = process.env.BEDROCK_AGENT_ID
+  ? createTeeStream(process.stdout, createCloudWatchStream(LOG_GROUP, region))
+  : process.stdout;
+```
+
+Then passed to the app:
+
+```typescript
+// src/app.ts, lines 146-155
+export const app = new BedrockAgentCoreApp({
+  config: { logging: { options: { stream: logStream } } },
+  invocationHandler: {
+    requestSchema: z.object({
+      url: z.string().url().describe("URL of the recipe page to extract"),
+    }),
+    process: processHandler,
+  },
+});
+```
+
+`config.logging.options.stream` is piped directly to Pino — BedrockAgentCoreApp uses Pino under the hood via Fastify.
+
+## IAM Permissions
+
+The execution role needs CloudWatch Logs permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ],
+    "Resource": "arn:aws:logs:us-west-2:ACCOUNT_ID:log-group:/aws/bedrock/agentcore/recipe-extraction-agent:*"
+  }]
+}
+```
+
+This is automatically configured by the deploy script (see [Part 6](./06-aws-infrastructure-setup.md)).
+
+## Viewing Logs
+
+After deployment, view logs in the AWS Console:
+
+1. Open [CloudWatch Logs](https://console.aws.amazon.com/cloudwatch/home#logsV2:log-groups) in `us-west-2`
+2. Find log group: `/aws/bedrock/agentcore/recipe-extraction-agent`
+3. Click into the latest log stream
+
+Or via CLI:
+
+```bash
+aws logs tail "/aws/bedrock/agentcore/recipe-extraction-agent" \
+  --region us-west-2 \
+  --follow
+```
+
+Each log line is a Pino JSON object with fields like:
+
+```json
+{
+  "level": 30,
+  "time": 1706000000000,
+  "msg": "Extracting recipe",
+  "url": "https://pinchofyum.com/..."
+}
+```
+
+---
+
+[Next: Docker & Container Build ->](./05-docker-and-container-build.md)

--- a/docs/deployment-guide/05-docker-and-container-build.md
+++ b/docs/deployment-guide/05-docker-and-container-build.md
@@ -1,0 +1,144 @@
+# Part 5: Docker & Container Build
+
+[<- Back to Index](./README.md) | [Previous: Observability](./04-observability-cloudwatch-logs.md) | [Next: AWS Infrastructure ->](./06-aws-infrastructure-setup.md)
+
+---
+
+## Why ARM64?
+
+AgentCore runs containers on **AWS Graviton** processors (ARM64 architecture). If you build an x86/amd64 image and deploy it to AgentCore, it will fail to start. Every build must target `linux/arm64`.
+
+## The Dockerfile
+
+A multi-stage build that separates TypeScript compilation from the production image:
+
+```dockerfile
+# Dockerfile
+
+# Build stage
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/node:20-slim AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Production stage
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/node:20-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
+COPY --from=builder /app/dist/ ./dist/
+EXPOSE 8080
+CMD ["node", "dist/main.js"]
+```
+
+### Stage 1: Builder
+
+| Line | Purpose |
+|---|---|
+| `FROM --platform=linux/arm64 ... AS builder` | ARM64 base image with Node 20 |
+| `COPY package.json package-lock.json` | Copy dependency manifests first (layer caching) |
+| `npm ci --ignore-scripts` | Install all deps (including devDependencies for `tsc`) |
+| `COPY tsconfig.json ./` and `COPY src/ ./src/` | Copy source files |
+| `npm run build` | Run `tsc` — compiles TypeScript to `dist/` |
+
+### Stage 2: Production
+
+| Line | Purpose |
+|---|---|
+| `FROM --platform=linux/arm64 ... node:20-slim` | Fresh slim image (no build artifacts) |
+| `npm ci --omit=dev --ignore-scripts` | Install only production dependencies |
+| `COPY --from=builder /app/dist/ ./dist/` | Copy compiled JS from builder stage |
+| `EXPOSE 8080` | Document the port (AgentCore expects 8080) |
+| `CMD ["node", "dist/main.js"]` | Start the agent |
+
+**Why `--ignore-scripts`?** Prevents `prepare` and other lifecycle scripts from running during `npm ci`. Inside Docker, there's no git repo, so the `prepare` script (`git config core.hooksPath .githooks`) would fail.
+
+**Why `node:20-slim`?** The `-slim` variant excludes build tools (gcc, make, python) that aren't needed at runtime. This keeps the image smaller.
+
+**Why public ECR?** `public.ecr.aws/docker/library/node:20-slim` is the official Node image hosted on Amazon's public ECR registry. It avoids Docker Hub rate limits in CI environments.
+
+## .dockerignore
+
+```
+node_modules
+dist
+tests
+.git
+.github
+.githooks
+.env
+*.md
+coverage
+```
+
+Keeps the Docker build context small and prevents sensitive files (`.env`) from being included in the image.
+
+## Building Locally
+
+### Standard build
+
+```bash
+docker build --platform linux/arm64 -t recipe-extraction-agent .
+```
+
+### Apple Silicon (M1/M2/M3/M4)
+
+On Apple Silicon Macs, Docker runs ARM64 natively — the build will be fast:
+
+```bash
+docker build --platform linux/arm64 -t recipe-extraction-agent .
+```
+
+### Intel/AMD Macs and Linux
+
+On x86 machines, Docker uses QEMU emulation for ARM64 builds. This is **significantly slower** (5-10x). The build works but expect longer compile times.
+
+For CI, we use Docker Buildx with GitHub Actions (which supports ARM64 natively via QEMU) — see [Part 8](./08-ci-cd-with-github-actions.md).
+
+## Running the Container Locally
+
+```bash
+docker run -p 8080:8080 --env-file .env recipe-extraction-agent
+```
+
+This maps port 8080 from the container to your host. The `--env-file .env` flag passes your local environment variables (AWS credentials, AIRS keys) into the container.
+
+> **Note:** Your `.env` file needs valid AWS credentials for Bedrock access. If you're using AWS profiles or SSO, you may need to pass credentials differently:
+>
+> ```bash
+> docker run -p 8080:8080 \
+>   -e AWS_ACCESS_KEY_ID \
+>   -e AWS_SECRET_ACCESS_KEY \
+>   -e AWS_SESSION_TOKEN \
+>   -e AWS_REGION=us-west-2 \
+>   recipe-extraction-agent
+> ```
+
+### Test the container
+
+```bash
+# Health check
+curl http://localhost:8080/ping
+
+# Invoke
+curl -X POST http://localhost:8080/invocations \
+  -H "Content-Type: application/json" \
+  -H "x-amzn-bedrock-agentcore-runtime-session-id: test-session-1" \
+  -d '{"url": "https://pinchofyum.com/chicken-wontons-in-spicy-chili-sauce"}'
+```
+
+## Image Size
+
+The multi-stage build produces a lean production image:
+
+- **Builder stage:** ~400MB (includes TypeScript, devDependencies)
+- **Production image:** ~200MB (Node 20 slim + production deps + compiled JS)
+
+The biggest contributors to image size are the AWS SDK packages (`@aws-sdk/client-*`). These are tree-shaken at the module level but still add significant weight.
+
+---
+
+[Next: AWS Infrastructure Setup ->](./06-aws-infrastructure-setup.md)

--- a/docs/deployment-guide/06-aws-infrastructure-setup.md
+++ b/docs/deployment-guide/06-aws-infrastructure-setup.md
@@ -1,0 +1,236 @@
+# Part 6: AWS Infrastructure Setup
+
+[<- Back to Index](./README.md) | [Previous: Docker Build](./05-docker-and-container-build.md) | [Next: Deploying to AgentCore ->](./07-deploying-to-agentcore.md)
+
+---
+
+## Resource Overview
+
+Before deploying the agent, three AWS resources need to be created:
+
+| Resource | Name | Purpose |
+|---|---|---|
+| **Secrets Manager secret** | `recipe-agent/prisma-airs-api-key` | Stores the Prisma AIRS API key |
+| **IAM execution role** | `BedrockAgentCoreRecipeAgent` | Permissions for the running container |
+| **ECR repository** | `recipe-extraction-agent` | Docker image registry |
+
+The deploy script (`scripts/deploy.sh`) creates the IAM role and ECR repo automatically. The Secrets Manager secret is created separately with `scripts/setup-secrets.sh`.
+
+## 1. Secrets Manager
+
+The AIRS API key needs to be stored securely — not baked into the Docker image or passed as a plain environment variable.
+
+### `scripts/setup-secrets.sh`
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-west-2}"
+SECRET_NAME="recipe-agent/prisma-airs-api-key"
+
+if [[ -z "${PRISMA_AIRS_API_KEY:-}" ]]; then
+  echo "ERROR: PRISMA_AIRS_API_KEY env var required" >&2
+  exit 1
+fi
+
+echo "==> Creating secret: ${SECRET_NAME}"
+
+if aws secretsmanager describe-secret \
+    --secret-id "${SECRET_NAME}" --region "${REGION}" &>/dev/null; then
+  echo "    Secret already exists. Updating value..."
+  aws secretsmanager put-secret-value \
+    --secret-id "${SECRET_NAME}" \
+    --secret-string "${PRISMA_AIRS_API_KEY}" \
+    --region "${REGION}"
+  echo "    Updated."
+else
+  aws secretsmanager create-secret \
+    --name "${SECRET_NAME}" \
+    --secret-string "${PRISMA_AIRS_API_KEY}" \
+    --description "Prisma AIRS API key for recipe-extraction-agent" \
+    --region "${REGION}"
+  echo "    Created."
+fi
+```
+
+**Usage:**
+
+```bash
+PRISMA_AIRS_API_KEY=your-key-here scripts/setup-secrets.sh
+```
+
+The script is idempotent — if the secret already exists, it updates the value.
+
+At runtime, `src/main.ts` fetches this secret during bootstrap:
+
+```typescript
+const secret = await sm.send(
+  new GetSecretValueCommand({ SecretId: "recipe-agent/prisma-airs-api-key" }),
+);
+```
+
+> **Note:** If you're not using Prisma AIRS, you can skip this step entirely. The agent works without it.
+
+## 2. IAM Execution Role
+
+The AgentCore runtime assumes an IAM role to access AWS services. The deploy script creates `BedrockAgentCoreRecipeAgent` with four policies:
+
+### Trust Policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+This allows the AgentCore service to assume the role on behalf of your container.
+
+### Policy 1: ECR Read (AWS Managed)
+
+```
+arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+```
+
+Allows AgentCore to pull the Docker image from ECR.
+
+### Policy 2: Bedrock Invoke Model
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream"
+    ],
+    "Resource": [
+      "arn:aws:bedrock:*::foundation-model/*",
+      "arn:aws:bedrock:*:ACCOUNT_ID:inference-profile/*"
+    ]
+  }]
+}
+```
+
+Grants access to invoke Bedrock models. Two resource ARNs are needed:
+- `foundation-model/*` — direct model access
+- `inference-profile/*` — cross-region inference profiles (the `us.` prefix in the model ID)
+
+### Policy 3: Secrets Manager Read
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["secretsmanager:GetSecretValue"],
+    "Resource": "arn:aws:secretsmanager:us-west-2:ACCOUNT_ID:secret:recipe-agent/*"
+  }]
+}
+```
+
+Allows reading the AIRS API key secret. Scoped to the `recipe-agent/` prefix.
+
+### Policy 4: CloudWatch Logs
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ],
+    "Resource": "arn:aws:logs:us-west-2:ACCOUNT_ID:log-group:/aws/bedrock/agentcore/recipe-extraction-agent:*"
+  }]
+}
+```
+
+Allows the CloudWatch stream (from [Part 4](./04-observability-cloudwatch-logs.md)) to create log streams and write events.
+
+### Creation in the deploy script
+
+The IAM role section in `scripts/deploy.sh`:
+
+```bash
+ROLE_NAME="BedrockAgentCoreRecipeAgent"
+
+TRUST_POLICY='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}'
+
+if ! aws iam get-role --role-name "${ROLE_NAME}" &>/dev/null; then
+  aws iam create-role \
+    --role-name "${ROLE_NAME}" \
+    --assume-role-policy-document "${TRUST_POLICY}" \
+    --description "Execution role for recipe-extraction-agent on AgentCore"
+
+  aws iam attach-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-arn arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+
+  aws iam put-role-policy --role-name "${ROLE_NAME}" \
+    --policy-name BedrockInvokeModel --policy-document '...'
+
+  aws iam put-role-policy --role-name "${ROLE_NAME}" \
+    --policy-name SecretsManagerRead --policy-document '...'
+
+  aws iam put-role-policy --role-name "${ROLE_NAME}" \
+    --policy-name CloudWatchLogs --policy-document '...'
+
+  echo "Created role. Waiting for propagation..."
+  sleep 10
+else
+  echo "Role already exists."
+fi
+```
+
+The `sleep 10` after creation gives IAM time to propagate globally — without it, the `create-agent-runtime` call may fail with "role not found."
+
+## 3. ECR Repository
+
+```bash
+REPO="recipe-extraction-agent"
+
+if ! aws ecr describe-repositories \
+    --repository-names "${REPO}" --region "${REGION}" &>/dev/null; then
+  aws ecr create-repository --repository-name "${REPO}" --region "${REGION}"
+  echo "Created ECR repository."
+else
+  echo "ECR repository already exists."
+fi
+```
+
+Idempotent — skips if the repo already exists.
+
+## Environment Variable Reference
+
+Complete list of environment variables used across the project:
+
+| Variable | Where Set | Required | Description |
+|---|---|---|---|
+| `AWS_REGION` | `.env` / runtime env | No (defaults to `us-west-2`) | AWS region for all service calls |
+| `AWS_ACCOUNT_ID` | `.env` / runtime env | No | Used for agent ARN in AIRS metadata |
+| `PRISMA_AIRS_API_KEY` | Secrets Manager | No | AIRS API key (fetched at bootstrap) |
+| `PRISMA_AIRS_PROFILE_NAME` | Runtime env var | No | AIRS security profile name |
+| `PRISMA_AIRS_API_URL` | `.env` | No | Override AIRS API endpoint |
+| `BEDROCK_AGENT_ID` | Runtime env var | No | AgentCore runtime ID (enables CloudWatch + AIRS metadata) |
+| `BEDROCK_AGENT_VERSION` | Runtime env var | No | Agent version (defaults to "1") |
+| `AGENTCORE_RUNTIME_ID` | `.env` / CI secret | For `--update` | Runtime ID for update deploys |
+
+---
+
+[Next: Deploying to AgentCore ->](./07-deploying-to-agentcore.md)

--- a/docs/deployment-guide/07-deploying-to-agentcore.md
+++ b/docs/deployment-guide/07-deploying-to-agentcore.md
@@ -1,0 +1,240 @@
+# Part 7: Deploying to AgentCore
+
+[<- Back to Index](./README.md) | [Previous: Infrastructure](./06-aws-infrastructure-setup.md) | [Next: CI/CD ->](./08-ci-cd-with-github-actions.md)
+
+---
+
+## Deploy Script Overview
+
+`scripts/deploy.sh` handles the full deployment lifecycle:
+
+```
+scripts/deploy.sh            # First deploy: IAM + ECR + build + push + create runtime
+scripts/deploy.sh --update   # Subsequent: build + push + update runtime
+```
+
+The script is idempotent for infrastructure (IAM, ECR) and linear for the deploy itself.
+
+## First Deploy
+
+Run the deploy script with no arguments:
+
+```bash
+scripts/deploy.sh
+```
+
+This executes five steps:
+
+### Step 1: IAM Role
+
+Creates `BedrockAgentCoreRecipeAgent` with all required policies (covered in [Part 6](./06-aws-infrastructure-setup.md)).
+
+### Step 2: ECR Repository
+
+Creates the `recipe-extraction-agent` ECR repository.
+
+### Step 3: Build & Push
+
+```bash
+# Compile TypeScript
+npm run build
+
+# Build ARM64 Docker image
+docker build --platform linux/arm64 -t recipe-extraction-agent .
+
+# Tag and push to ECR
+docker tag recipe-extraction-agent:latest \
+  ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/recipe-extraction-agent:latest
+
+aws ecr get-login-password --region ${REGION} | \
+  docker login --username AWS --password-stdin \
+  ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com
+
+docker push ${ECR_URI}:latest
+```
+
+### Step 4: Create AgentCore Runtime
+
+```bash
+aws bedrock-agentcore-control create-agent-runtime \
+  --agent-runtime-name recipe_extraction_agent \
+  --agent-runtime-artifact '{"containerConfiguration":{"containerUri":"ECR_URI:latest"}}' \
+  --role-arn "${ROLE_ARN}" \
+  --network-configuration '{"networkMode":"PUBLIC"}' \
+  --protocol-configuration '{"serverProtocol":"HTTP"}' \
+  --environment-variables '{"AWS_REGION":"us-west-2","AWS_ACCOUNT_ID":"..."}' \
+  --region us-west-2
+```
+
+**Key parameters:**
+
+| Parameter | Value | Purpose |
+|---|---|---|
+| `--agent-runtime-name` | `recipe_extraction_agent` | Display name in the console |
+| `--agent-runtime-artifact` | Container URI in ECR | Points to your Docker image |
+| `--role-arn` | IAM execution role ARN | Permissions for the container |
+| `--network-configuration` | `PUBLIC` | Container has internet access (needed for recipe URLs) |
+| `--protocol-configuration` | `HTTP` | Fastify HTTP server (not WebSocket) |
+| `--environment-variables` | JSON object | Env vars injected into the container |
+
+The command returns the **runtime ID**:
+
+```
+Runtime ID: abc123-def456-...
+Save this as AGENTCORE_RUNTIME_ID and BEDROCK_AGENT_ID for future deploys.
+```
+
+> **Important:** The first deploy does **not** set `BEDROCK_AGENT_ID` in the container's environment (because we don't know the runtime ID until after creation). Run `--update` immediately after to inject it.
+
+### Step 5: Poll for READY
+
+```bash
+for i in $(seq 1 30); do
+  STATUS=$(aws bedrock-agentcore-control get-agent-runtime \
+    --agent-runtime-id "${RUNTIME_ID}" \
+    --region us-west-2 \
+    --query 'status' --output text)
+
+  echo "Status: ${STATUS} (attempt ${i}/30)"
+
+  if [[ "${STATUS}" == "READY" ]]; then
+    echo "Runtime is READY!"
+    exit 0
+  elif [[ "${STATUS}" == "FAILED" ]]; then
+    echo "Runtime FAILED" >&2
+    exit 1
+  fi
+
+  sleep 10
+done
+```
+
+The script polls every 10 seconds for up to 5 minutes. AgentCore typically takes 1-3 minutes to pull the image and start the container.
+
+## Save the Runtime ID
+
+After the first deploy, save the runtime ID in your `.env`:
+
+```bash
+# .env
+AGENTCORE_RUNTIME_ID=abc123-def456-...
+```
+
+Then immediately run an update to inject `BEDROCK_AGENT_ID`:
+
+```bash
+scripts/deploy.sh --update
+```
+
+## Subsequent Deploys
+
+With `AGENTCORE_RUNTIME_ID` set:
+
+```bash
+scripts/deploy.sh --update
+```
+
+This skips IAM/ECR creation and goes straight to:
+1. Build TypeScript
+2. Build Docker image
+3. Push to ECR
+4. Update the runtime
+
+The update command:
+
+```bash
+aws bedrock-agentcore-control update-agent-runtime \
+  --agent-runtime-id "${AGENTCORE_RUNTIME_ID}" \
+  --agent-runtime-artifact '{"containerConfiguration":{"containerUri":"ECR_URI:latest"}}' \
+  --role-arn "${ROLE_ARN}" \
+  --network-configuration '{"networkMode":"PUBLIC"}' \
+  --protocol-configuration '{"serverProtocol":"HTTP"}' \
+  --environment-variables '{"AWS_REGION":"...","BEDROCK_AGENT_ID":"...","PRISMA_AIRS_PROFILE_NAME":"..."}' \
+  --region us-west-2
+```
+
+On updates, the environment variables include `BEDROCK_AGENT_ID` (set to the runtime ID), which enables:
+- CloudWatch log shipping (see [Part 4](./04-observability-cloudwatch-logs.md))
+- Agent metadata in AIRS scans (see [Part 3](./03-security-with-prisma-airs.md))
+
+## Testing the Deployment
+
+Once the runtime is READY, invoke it via the AWS CLI:
+
+```bash
+aws bedrock-agentcore invoke-agent-runtime \
+  --agent-runtime-id "${AGENTCORE_RUNTIME_ID}" \
+  --payload '{"url": "https://pinchofyum.com/chicken-wontons-in-spicy-chili-sauce"}' \
+  --region us-west-2 \
+  output.json
+
+cat output.json | jq .
+```
+
+Expected response:
+
+```json
+{
+  "title": "Chicken Wontons in Spicy Chili Sauce",
+  "ingredients": [...],
+  "preparationSteps": [...],
+  "cookingSteps": [...],
+  "notes": {
+    "servings": "4 servings",
+    "cookTime": "10 minutes",
+    "prepTime": "30 minutes"
+  }
+}
+```
+
+## Troubleshooting
+
+### Runtime stuck in CREATING
+
+AgentCore pulls the image from ECR and starts the container. This typically takes 1-3 minutes. If it's been more than 5 minutes:
+
+```bash
+aws bedrock-agentcore-control get-agent-runtime \
+  --agent-runtime-id "${AGENTCORE_RUNTIME_ID}" \
+  --region us-west-2
+```
+
+Check the `status` and `statusReasons` fields.
+
+### Runtime enters FAILED
+
+Common causes:
+
+| Issue | Fix |
+|---|---|
+| **Wrong architecture** | Ensure `--platform linux/arm64` in your Docker build |
+| **Missing IAM permissions** | Check the execution role has all four policies |
+| **Container crash** | Test locally first: `docker run -p 8080:8080 --env-file .env recipe-extraction-agent` |
+| **Port mismatch** | The container must listen on port 8080 |
+| **Health check timeout** | `/ping` must respond within 30 seconds of container start |
+
+### Inference profile ARNs
+
+If you see "access denied" errors when invoking Bedrock models, check that the IAM role includes `inference-profile/*` in its resource ARNs:
+
+```json
+"Resource": [
+  "arn:aws:bedrock:*::foundation-model/*",
+  "arn:aws:bedrock:*:ACCOUNT_ID:inference-profile/*"
+]
+```
+
+The `us.` prefix in `us.anthropic.claude-haiku-4-5-20251001-v1:0` uses cross-region inference profiles, which require the second ARN pattern.
+
+### Debugging with logs
+
+If the container starts but invocations fail, check CloudWatch:
+
+```bash
+aws logs tail "/aws/bedrock/agentcore/recipe-extraction-agent" \
+  --region us-west-2 --follow
+```
+
+---
+
+[Next: CI/CD with GitHub Actions ->](./08-ci-cd-with-github-actions.md)

--- a/docs/deployment-guide/08-ci-cd-with-github-actions.md
+++ b/docs/deployment-guide/08-ci-cd-with-github-actions.md
@@ -1,0 +1,369 @@
+# Part 8: CI/CD with GitHub Actions
+
+[<- Back to Index](./README.md) | [Previous: Deploying](./07-deploying-to-agentcore.md) | [Next: Teardown ->](./09-teardown.md)
+
+---
+
+## Overview
+
+The project has two GitHub Actions workflows:
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| **CI** (`.github/workflows/ci.yml`) | PR to main, push to main | Typecheck, lint, test |
+| **Deploy** (`.github/workflows/deploy.yml`) | Push to main (source changes) | Build, push to ECR, update runtime |
+
+Plus a local pre-commit hook that catches issues before they reach CI.
+
+## Local Quality Gates
+
+### Pre-commit Hook
+
+`.githooks/pre-commit` runs three checks before every commit:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> typecheck"
+npm run typecheck
+
+echo "==> lint + format"
+npm run check
+
+echo "==> test"
+npm test
+```
+
+This is configured automatically during `npm install` via the `prepare` script:
+
+```json
+{
+  "scripts": {
+    "prepare": "git config core.hooksPath .githooks"
+  }
+}
+```
+
+If any check fails, the commit is rejected. Fix the issue, re-stage, and commit again.
+
+## CI Workflow
+
+`.github/workflows/ci.yml` — runs on every PR and push to main:
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint & format
+        run: npm run check
+
+      - name: Test
+        run: npm run test:coverage
+```
+
+This mirrors the pre-commit hook but runs in a clean environment and includes coverage reporting. The CI job uses Node 22 (latest LTS) for validation — the runtime uses Node 20 (matching the Docker image).
+
+## GitHub OIDC Setup
+
+The deploy workflow uses **GitHub OIDC** to authenticate with AWS — no long-lived credentials needed. GitHub Actions requests a short-lived token from AWS STS, scoped to your repository.
+
+### Prerequisites
+
+1. A GitHub OIDC identity provider must exist in your AWS account. If it doesn't:
+
+```bash
+aws iam create-open-id-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --client-id-list sts.amazonaws.com \
+  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+```
+
+2. The AgentCore runtime must already be created (see [Part 7](./07-deploying-to-agentcore.md)).
+
+### `scripts/setup-github-iam.sh`
+
+This script creates the `github-actions-recipe-agent` IAM role:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-west-2}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+ROLE_NAME="github-actions-recipe-agent"
+REPO="cdot65/aws-bedrock-agentcore-typescript-example"
+ECR_REPO="recipe-extraction-agent"
+RUNTIME_ID="${AGENTCORE_RUNTIME_ID:-recipe_extraction_agent-wkubdE7YBy}"
+```
+
+### Trust Policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+      },
+      "StringLike": {
+        "token.actions.githubusercontent.com:sub": "repo:cdot65/aws-bedrock-agentcore-typescript-example:*"
+      }
+    }
+  }]
+}
+```
+
+The `StringLike` condition scopes the role to your specific GitHub repository. Only workflows running from this repo can assume the role.
+
+### ECR Push Policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ],
+      "Resource": "arn:aws:ecr:us-west-2:ACCOUNT_ID:repository/recipe-extraction-agent"
+    }
+  ]
+}
+```
+
+### AgentCore Deploy Policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:UpdateAgentRuntime",
+        "bedrock-agentcore:GetAgentRuntime"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:ACCOUNT_ID:runtime/RUNTIME_ID"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::ACCOUNT_ID:role/BedrockAgentCoreRecipeAgent",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "bedrock-agentcore.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+```
+
+The `iam:PassRole` permission is required because `update-agent-runtime` passes the execution role to AgentCore.
+
+### Run the setup script
+
+```bash
+AGENTCORE_RUNTIME_ID=your-runtime-id scripts/setup-github-iam.sh
+```
+
+The script outputs the commands to set GitHub secrets:
+
+```
+Set GitHub repo secrets:
+  gh secret set AWS_ROLE_ARN -b "arn:aws:iam::123456789012:role/github-actions-recipe-agent"
+  gh secret set AGENTCORE_RUNTIME_ID -b "your-runtime-id"
+  gh secret set AGENTCORE_ROLE_ARN -b "arn:aws:iam::123456789012:role/BedrockAgentCoreRecipeAgent"
+```
+
+## GitHub Secrets
+
+Three secrets are needed in your repository:
+
+| Secret | Value | Purpose |
+|---|---|---|
+| `AWS_ROLE_ARN` | `arn:aws:iam::...:role/github-actions-recipe-agent` | OIDC role for CI/CD |
+| `AGENTCORE_RUNTIME_ID` | Runtime ID from first deploy | Target runtime to update |
+| `AGENTCORE_ROLE_ARN` | `arn:aws:iam::...:role/BedrockAgentCoreRecipeAgent` | Execution role passed to runtime |
+
+Set them with the `gh` CLI:
+
+```bash
+gh secret set AWS_ROLE_ARN -b "arn:aws:iam::123456789012:role/github-actions-recipe-agent"
+gh secret set AGENTCORE_RUNTIME_ID -b "your-runtime-id"
+gh secret set AGENTCORE_ROLE_ARN -b "arn:aws:iam::123456789012:role/BedrockAgentCoreRecipeAgent"
+```
+
+## Deploy Workflow
+
+`.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy to AgentCore
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - "Dockerfile"
+      - "tsconfig.json"
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REGISTRY: 585768170262.dkr.ecr.us-west-2.amazonaws.com
+  ECR_REPOSITORY: recipe-extraction-agent
+
+permissions:
+  id-token: write
+  contents: read
+```
+
+### Triggers
+
+- **Push to main** — only when source files, dependencies, or the Dockerfile change (via `paths` filter). README changes don't trigger a deploy.
+- **Manual dispatch** — `workflow_dispatch` lets you trigger from the GitHub Actions UI.
+
+### Permissions
+
+`id-token: write` is required for GitHub OIDC — it allows the workflow to request a token from AWS STS.
+
+### Build & Push Steps
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+
+  - name: Configure AWS credentials
+    uses: aws-actions/configure-aws-credentials@v4
+    with:
+      role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+      aws-region: ${{ env.AWS_REGION }}
+
+  - name: Login to Amazon ECR
+    uses: aws-actions/amazon-ecr-login@v2
+
+  - name: Set up Docker Buildx
+    uses: docker/setup-buildx-action@v3
+
+  - name: Build and push
+    uses: docker/build-push-action@v6
+    with:
+      context: .
+      push: true
+      platforms: linux/arm64
+      tags: |
+        ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
+        ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:sha-${{ github.sha }}
+      cache-from: type=gha
+      cache-to: type=gha,mode=max
+```
+
+**Image tagging:** Each build produces two tags:
+- `latest` — always points to the newest image
+- `sha-{commit}` — immutable tag tied to the exact commit
+
+**Build caching:** `cache-from: type=gha` uses GitHub Actions cache for Docker layer caching. Subsequent builds only rebuild changed layers.
+
+### Update Runtime
+
+```yaml
+  - name: Update AgentCore runtime
+    run: |
+      aws bedrock-agentcore-control update-agent-runtime \
+        --agent-runtime-id "${{ secrets.AGENTCORE_RUNTIME_ID }}" \
+        --agent-runtime-artifact "{\"containerConfiguration\":{\"containerUri\":\"${ECR_REGISTRY}/${ECR_REPOSITORY}:sha-${GITHUB_SHA}\"}}" \
+        --role-arn "${{ secrets.AGENTCORE_ROLE_ARN }}" \
+        --network-configuration '{"networkMode":"PUBLIC"}' \
+        --protocol-configuration '{"serverProtocol":"HTTP"}' \
+        --environment-variables "{\"AWS_REGION\":\"${AWS_REGION}\",...}" \
+        --region "${AWS_REGION}"
+```
+
+Note: The deploy workflow uses the `sha-{commit}` tag (not `latest`) for the container URI. This ensures the runtime pulls the exact image that was just built.
+
+### Poll for READY
+
+```yaml
+  - name: Wait for READY status
+    timeout-minutes: 5
+    run: |
+      for i in $(seq 1 30); do
+        STATUS=$(aws bedrock-agentcore-control get-agent-runtime \
+          --agent-runtime-id "${{ secrets.AGENTCORE_RUNTIME_ID }}" \
+          --region "${AWS_REGION}" \
+          --query 'status' --output text 2>/dev/null || echo "UNKNOWN")
+        echo "Status: ${STATUS} (attempt ${i}/30)"
+        if [[ "${STATUS}" == "READY" ]]; then
+          echo "Runtime is READY!"
+          exit 0
+        elif [[ "${STATUS}" == "FAILED" ]]; then
+          echo "Runtime FAILED" >&2
+          exit 1
+        fi
+        sleep 10
+      done
+      echo "Timeout waiting for READY" >&2
+      exit 1
+```
+
+## End-to-End Flow
+
+```mermaid
+graph LR
+    Push["Push to main<br/>(src/ changes)"] --> CI["CI Job<br/>typecheck + lint + test"]
+    Push --> Deploy["Deploy Job"]
+    Deploy --> OIDC["OIDC Auth<br/>→ AWS credentials"]
+    OIDC --> ECR["ECR Login<br/>+ Docker Build<br/>+ Push"]
+    ECR --> Update["update-agent-runtime<br/>(sha-tagged image)"]
+    Update --> Poll["Poll for READY<br/>(5 min timeout)"]
+```
+
+Both CI and Deploy run in parallel on push to main. CI validates code quality; Deploy builds and ships to AgentCore.
+
+---
+
+[Next: Teardown ->](./09-teardown.md)

--- a/docs/deployment-guide/09-teardown.md
+++ b/docs/deployment-guide/09-teardown.md
@@ -1,0 +1,131 @@
+# Part 9: Teardown
+
+[<- Back to Index](./README.md) | [Previous: CI/CD](./08-ci-cd-with-github-actions.md)
+
+---
+
+To fully remove all AWS resources created by this project, run the following commands in order.
+
+> **Note:** Replace placeholder values (`RUNTIME_ID`, `ACCOUNT_ID`) with your actual values. Set the region if different from `us-west-2`.
+
+```bash
+REGION="us-west-2"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+```
+
+## 1. Delete AgentCore Runtime
+
+```bash
+aws bedrock-agentcore-control delete-agent-runtime \
+  --agent-runtime-id "${AGENTCORE_RUNTIME_ID}" \
+  --region "${REGION}"
+```
+
+## 2. Delete ECR Repository
+
+This deletes the repository and all images inside it:
+
+```bash
+aws ecr delete-repository \
+  --repository-name recipe-extraction-agent \
+  --region "${REGION}" \
+  --force
+```
+
+## 3. Delete IAM Execution Role
+
+Detach policies first, then delete the role:
+
+```bash
+# Detach managed policy
+aws iam detach-role-policy \
+  --role-name BedrockAgentCoreRecipeAgent \
+  --policy-arn arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+
+# Delete inline policies
+aws iam delete-role-policy \
+  --role-name BedrockAgentCoreRecipeAgent \
+  --policy-name BedrockInvokeModel
+
+aws iam delete-role-policy \
+  --role-name BedrockAgentCoreRecipeAgent \
+  --policy-name SecretsManagerRead
+
+aws iam delete-role-policy \
+  --role-name BedrockAgentCoreRecipeAgent \
+  --policy-name CloudWatchLogs
+
+# Delete the role
+aws iam delete-role --role-name BedrockAgentCoreRecipeAgent
+```
+
+## 4. Delete GitHub Actions IAM Role
+
+```bash
+# Delete inline policies
+aws iam delete-role-policy \
+  --role-name github-actions-recipe-agent \
+  --policy-name ecr-push
+
+aws iam delete-role-policy \
+  --role-name github-actions-recipe-agent \
+  --policy-name agentcore-deploy
+
+# Delete the role
+aws iam delete-role --role-name github-actions-recipe-agent
+```
+
+## 5. Delete Secrets Manager Secret
+
+```bash
+aws secretsmanager delete-secret \
+  --secret-id recipe-agent/prisma-airs-api-key \
+  --force-delete-without-recovery \
+  --region "${REGION}"
+```
+
+The `--force-delete-without-recovery` flag deletes immediately without the default 7-day recovery window.
+
+## 6. Delete CloudWatch Log Group
+
+```bash
+aws logs delete-log-group \
+  --log-group-name /aws/bedrock/agentcore/recipe-extraction-agent \
+  --region "${REGION}"
+```
+
+## 7. Remove GitHub Secrets
+
+```bash
+gh secret delete AWS_ROLE_ARN
+gh secret delete AGENTCORE_RUNTIME_ID
+gh secret delete AGENTCORE_ROLE_ARN
+```
+
+## Verification
+
+Confirm all resources are removed:
+
+```bash
+# Should all return errors or empty results
+aws bedrock-agentcore-control get-agent-runtime \
+  --agent-runtime-id "${AGENTCORE_RUNTIME_ID}" --region "${REGION}" 2>&1 || true
+
+aws ecr describe-repositories \
+  --repository-names recipe-extraction-agent --region "${REGION}" 2>&1 || true
+
+aws iam get-role --role-name BedrockAgentCoreRecipeAgent 2>&1 || true
+
+aws iam get-role --role-name github-actions-recipe-agent 2>&1 || true
+
+aws secretsmanager describe-secret \
+  --secret-id recipe-agent/prisma-airs-api-key --region "${REGION}" 2>&1 || true
+
+aws logs describe-log-groups \
+  --log-group-name-prefix /aws/bedrock/agentcore/recipe-extraction-agent \
+  --region "${REGION}"
+```
+
+---
+
+[<- Back to Index](./README.md)

--- a/docs/deployment-guide/README.md
+++ b/docs/deployment-guide/README.md
@@ -1,0 +1,66 @@
+# Deploying an AI Agent to AWS Bedrock AgentCore
+
+A nine-part guide to building, securing, and deploying a TypeScript AI agent on [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) — from local development to fully automated CI/CD.
+
+This series uses the **recipe-extraction-agent** as its running example: a production-ready agent that takes a URL, fetches the webpage, and returns structured recipe JSON using Claude Haiku 4.5.
+
+## Architecture
+
+```mermaid
+graph TB
+    Client([Client / curl])
+
+    subgraph AgentCore["BedrockAgentCoreApp (Fastify :8080)"]
+        Ping["GET /ping"]
+        Invoke["POST /invocations"]
+    end
+
+    subgraph Security["Prisma AIRS AI Runtime Security"]
+        PromptScan["Prompt Scan<br/>(pre-LLM)"]
+        ResponseScan["Response Scan<br/>(post-LLM)"]
+    end
+
+    subgraph StrandsAgent["Strands Agent"]
+        Model["BedrockModel<br/>Claude Haiku 4.5"]
+        SystemPrompt["System Prompt<br/>(extraction rules)"]
+        FetchTool["fetch_url tool"]
+    end
+
+    subgraph Processing["Response Processing"]
+        ExtractJSON["extractJson()<br/>parse LLM text output"]
+        ZodValidation["RecipeSchema.parse()<br/>Zod v4 validation"]
+    end
+
+    ExternalSite[(Recipe Website)]
+    Bedrock[(Amazon Bedrock<br/>us-west-2)]
+    AIRS[(Prisma AIRS API)]
+
+    Client -->|"POST {url}"| Invoke
+    Client -->|health check| Ping
+    Invoke --> PromptScan
+    PromptScan <-->|scan prompt| AIRS
+    PromptScan -->|allow| StrandsAgent
+    PromptScan -.->|block| Client
+    Model <-->|Converse API| Bedrock
+    Model -->|tool_use| FetchTool
+    FetchTool -->|GET| ExternalSite
+    ExternalSite -->|HTML + JSON-LD| Model
+    Model -->|JSON text| ExtractJSON
+    ExtractJSON --> ZodValidation
+    ZodValidation --> ResponseScan
+    ResponseScan <-->|scan response| AIRS
+    ResponseScan -->|allow| Client
+    ResponseScan -.->|block| Client
+```
+
+## Guide Contents
+
+1. [Introduction & Prerequisites](./01-introduction-and-prerequisites.md) — AI agent primer, project overview, local setup
+2. [Agent Architecture Deep Dive](./02-agent-architecture-deep-dive.md) — entry points, model config, tools, schemas, request flow
+3. [Security with Prisma AIRS](./03-security-with-prisma-airs.md) — AI runtime security, prompt/response scanning, fail-open design
+4. [Observability: CloudWatch Logs](./04-observability-cloudwatch-logs.md) — custom log shipping, Pino integration, tee streams
+5. [Docker & Container Build](./05-docker-and-container-build.md) — ARM64 multi-stage build, local testing
+6. [AWS Infrastructure Setup](./06-aws-infrastructure-setup.md) — IAM roles, ECR, Secrets Manager, env vars
+7. [Deploying to AgentCore](./07-deploying-to-agentcore.md) — first deploy, updates, polling, troubleshooting
+8. [CI/CD with GitHub Actions](./08-ci-cd-with-github-actions.md) — OIDC auth, automated builds, deploy pipeline
+9. [Teardown](./09-teardown.md) — clean removal of all AWS resources


### PR DESCRIPTION
## Summary

- Adds comprehensive deployment guide in `docs/deployment-guide/` (9 parts + index)
- Covers agent architecture, Prisma AIRS security, CloudWatch observability, Docker builds, AWS infra setup, AgentCore deployment, CI/CD with GitHub Actions, and teardown
- All code snippets reference current source files
- No source code changes — docs only

## Test plan

- [x] Pre-commit hook passes (typecheck, lint, 94 tests)
- [ ] CI passes
- [ ] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)