### PR TITLE
fix: restore CloudWatch stream for app logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "recipe-extraction-agent",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-cloudwatch-logs": "^3.1002.0",
         "@aws-sdk/client-secrets-manager": "^3.998.0",
         "@strands-agents/sdk": "^0.4.0",
         "bedrock-agentcore": "^0.2.0",
@@ -328,6 +329,59 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cloudwatch-logs": {
+      "version": "3.1002.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1002.0.tgz",
+      "integrity": "sha512-O0ov4W+IiMla4HhB3eAey5MxwjdGvVkhDne9wdLRD+2H2Ba8qtSq/FwdeyCUYha93E2T813orYaxppcYemiNjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/credential-provider-node": "^3.972.16",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.17",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.2",
+        "@smithy/config-resolver": "^4.4.9",
+        "@smithy/core": "^3.23.7",
+        "@smithy/eventstream-serde-browser": "^4.2.10",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.10",
+        "@smithy/eventstream-serde-node": "^4.2.10",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/hash-node": "^4.2.10",
+        "@smithy/invalid-dependency": "^4.2.10",
+        "@smithy/middleware-content-length": "^4.2.10",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
+        "@smithy/middleware-serde": "^4.2.11",
+        "@smithy/middleware-stack": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-http-handler": "^4.4.13",
+        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/smithy-client": "^4.12.1",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.10",
+        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-body-length-browser": "^4.2.1",
+        "@smithy/util-body-length-node": "^4.2.2",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
+        "@smithy/util-endpoints": "^3.3.1",
+        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-retry": "^4.2.10",
+        "@smithy/util-utf8": "^4.2.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-cognito-identity": {
       "version": "3.998.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.998.0.tgz",
@@ -429,19 +483,19 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.14.tgz",
-      "integrity": "sha512-iAQ1jIGESTVjoqNNY9VlsE9FnCz+Hc8s+dgurF6WrgFyVIw+uggH+V102RFhwjRv4dLSSLfzjDwvQnLszov7TQ==",
+      "version": "3.973.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.17.tgz",
+      "integrity": "sha512-VtgGP0TjbCeyp6DQpiBqJKbemTSIaN2bZc3UbeTDCani3lBCyxn75ouJYD6koSSp0bh7rKLEbUpiFsNCI7tr0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/xml-builder": "^3.972.7",
-        "@smithy/core": "^3.23.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/xml-builder": "^3.972.9",
+        "@smithy/core": "^3.23.7",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/signature-v4": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/smithy-client": "^4.12.1",
         "@smithy/types": "^4.13.0",
         "@smithy/util-base64": "^4.3.1",
         "@smithy/util-middleware": "^4.2.10",
@@ -469,13 +523,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.12.tgz",
-      "integrity": "sha512-WPtj/iAYHHd+NDM6AZoilZwUz0nMaPxbTPGLA7nhyIYRZN2L8trqfbNvm7g/Jr3gzfKp1LpO6AtBTnrhz9WW2g==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.15.tgz",
+      "integrity": "sha512-RhHQG1lhkWHL4tK1C/KDjaOeis+9U0tAMnWDiwiSVQZMC7CsST9Xin+sK89XywJ5g/tyABtb7TvFePJ4Te5XSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -485,20 +539,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.14.tgz",
-      "integrity": "sha512-umtjCicH2o/Fcc8Fu1562UkDyt6gql4czTYVlUfHfAM8S4QEKggzmtHYYYpPfQcjFj1ajyy68ahYSuF67x4ptQ==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.17.tgz",
+      "integrity": "sha512-b/bDL76p51+yQ+0O9ZDH5nw/ioE0sRYkjwjOwFWAWZXo6it2kQZUOXhVpjohx3ldKyUxt/SwAivjUu1Nr/PWlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/node-http-handler": "^4.4.12",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/fetch-http-handler": "^5.3.12",
+        "@smithy/node-http-handler": "^4.4.13",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/smithy-client": "^4.12.1",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.15",
+        "@smithy/util-stream": "^4.5.16",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -506,20 +560,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.12.tgz",
-      "integrity": "sha512-qjzgnMl6GIBbVeK74jBqSF07+s6kyeZl5R88qjMs302JlqkxE57jkvflDmZ9I017ffEWqIUa9/M4Hfp28qyu1g==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.15.tgz",
+      "integrity": "sha512-qWnM+wB8MmU2kKY7f4KowKjOjkwRosaFxrtseEEIefwoXn1SjN+CbHzXBVdTAQxxkbBiqhPgJ/WHiPtES4grRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-env": "^3.972.12",
-        "@aws-sdk/credential-provider-http": "^3.972.14",
-        "@aws-sdk/credential-provider-login": "^3.972.12",
-        "@aws-sdk/credential-provider-process": "^3.972.12",
-        "@aws-sdk/credential-provider-sso": "^3.972.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.12",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/credential-provider-env": "^3.972.15",
+        "@aws-sdk/credential-provider-http": "^3.972.17",
+        "@aws-sdk/credential-provider-login": "^3.972.15",
+        "@aws-sdk/credential-provider-process": "^3.972.15",
+        "@aws-sdk/credential-provider-sso": "^3.972.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.15",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/credential-provider-imds": "^4.2.10",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -531,14 +585,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.12.tgz",
-      "integrity": "sha512-AO57y46PzG24bJzxWLk+FYJG6MzxvXoFXnOKnmKUGV43ub4/FS/4Rz7zCC6ThqUotgqEFd30l5LTAd65RP65pg==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.15.tgz",
+      "integrity": "sha512-x92FJy34/95wgu+qOGD8SHcgh1hZ9Qx2uFtQEGn4m9Ljou8ICIv3Ybq5yxdB7A60S8ZGCQB0mIopmjJwiLbh5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -550,18 +604,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.13.tgz",
-      "integrity": "sha512-ME2sgus+gFRtiudy5Xqj9iT/tj8lHOIGrFgktuO5skJU4EngOvTZ1Hpj8mknrW4FgWXmpWhc88NtEscUuuDpKw==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.16.tgz",
+      "integrity": "sha512-7mlt14Ee4rPFAFUVgpWE7+0CBhetJJyzVFqfIsMp7sgyOSm9Y/+qHZOWAuK5I4JNc+Y5PltvJ9kssTzRo92iXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.12",
-        "@aws-sdk/credential-provider-http": "^3.972.14",
-        "@aws-sdk/credential-provider-ini": "^3.972.12",
-        "@aws-sdk/credential-provider-process": "^3.972.12",
-        "@aws-sdk/credential-provider-sso": "^3.972.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.12",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/credential-provider-env": "^3.972.15",
+        "@aws-sdk/credential-provider-http": "^3.972.17",
+        "@aws-sdk/credential-provider-ini": "^3.972.15",
+        "@aws-sdk/credential-provider-process": "^3.972.15",
+        "@aws-sdk/credential-provider-sso": "^3.972.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.15",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/credential-provider-imds": "^4.2.10",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -573,13 +627,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.12.tgz",
-      "integrity": "sha512-msxrHBpVP5AOIDohNPCINUtL47f7XI1TEru3N13uM3nWUMvIRA1vFa8Tlxbxm1EntPPvLAxRmvE5EbjDjOZkbw==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.15.tgz",
+      "integrity": "sha512-PrH3iTeD18y/8uJvQD2s/T87BTGhsdS/1KZU7ReWHXsplBwvCqi7AbnnNbML1pFlQwRWCE2RdSZFWDVId3CvkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -590,15 +644,33 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.12.tgz",
-      "integrity": "sha512-D5iC5546hJyhobJN0szOT4KVeJQ8z/meZq2B3lEDZFcvHONKw+tzq36DAJUy3qLTueeB2geSxiHXngQlA11eoA==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.15.tgz",
+      "integrity": "sha512-M/+LBHTPKZxxXckM6m4dnJeR+jlm9NynH9b2YDswN4Zj2St05SK/crdL3Wy3WfJTZootnnhm3oTh87Usl7PS7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/token-providers": "3.998.0",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/token-providers": "3.1002.0",
+        "@aws-sdk/types": "^3.973.4",
+        "@smithy/property-provider": "^4.2.10",
+        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1002.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1002.0.tgz",
+      "integrity": "sha512-x972uKOydFn4Rb0PZJzLdNW59rH0KWC78Q2JbQzZpGlGt0DxjYdDRwBG6F42B1MyaEwHGqO/tkGc4r3/PRFfMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -609,14 +681,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.12.tgz",
-      "integrity": "sha512-yluBahBVsduoA/zgV0NAXtwwXvQ6tNn95dNA3Hg+vISdiPWA46QY0d9PLO2KpNbjtm+1oGcWxemS4fYTwJ0W1w==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.15.tgz",
+      "integrity": "sha512-QTH6k93v+UOfFam/ado8zc71tH+enTVyuvLy9uEWXX1x894dN5ovtf/MdBDgFwq3g6c9mbtgVJ4B+yBqDtXvdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/nested-clients": "^3.996.5",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -771,12 +843,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.5.tgz",
-      "integrity": "sha512-dVA0m1cEQ2iA6yB19aHvWNeUVTuvTt3AXzT0aiIu2uxk0S7AcmwDCDaRgYa/v+eFHcJVxEnpYTozqA7X62xinw==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.6.tgz",
+      "integrity": "sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -786,12 +858,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.5.tgz",
-      "integrity": "sha512-03RqplLZjUTkYi0dDPR/bbOLnDLFNdaVvNENgA3XK7Ph1MhEBhUYlgoGfOyRAKApDZ+WG4ykOoA8jI8J04jmFA==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.6.tgz",
+      "integrity": "sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -800,12 +872,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.5.tgz",
-      "integrity": "sha512-2QSuuVkpHTe84+mDdnFjHX8rAP3g0yYwLVAhS3lQN1rW5Z/zNsf8/pYQrLjLO4n4sPCsUAkTa0Vrod0lk+o1Tg==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.6.tgz",
+      "integrity": "sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
@@ -816,15 +888,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.14.tgz",
-      "integrity": "sha512-PzDz+yRAQuIzd+4ZY3s6/TYRzlNKAn4Gae3E5uLV7NnYHqrZHFoAfKE4beXcu3C51pA2/FQ3X2qOGSYqUoN1WQ==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.17.tgz",
+      "integrity": "sha512-HHArkgWzomuwufXwheQqkddu763PWCpoNTq1dGjqXzJT/lojX3VlOqjNSR2Xvb6/T9ISfwYcMOcbFgUp4EWxXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@smithy/core": "^3.23.6",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@smithy/core": "^3.23.7",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -857,44 +929,44 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.2.tgz",
-      "integrity": "sha512-W+u6EM8WRxOIhAhR2mXMHSaUygqItpTehkgxLwJngXqr9RlAR4t6CtECH7o7QK0ct3oyi5Z8ViDHtPbel+D2Rg==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.5.tgz",
+      "integrity": "sha512-zn0WApcULn7Rtl6T+KP2CQTZo/7wOa2YV1yHQnbijTQoi4YXQHM8s21JcJzt33/mqPh8AdvWX1f+83KvKuxlZw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
+        "@aws-sdk/core": "^3.973.17",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.17",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.2",
         "@smithy/config-resolver": "^4.4.9",
-        "@smithy/core": "^3.23.6",
-        "@smithy/fetch-http-handler": "^5.3.11",
+        "@smithy/core": "^3.23.7",
+        "@smithy/fetch-http-handler": "^5.3.12",
         "@smithy/hash-node": "^4.2.10",
         "@smithy/invalid-dependency": "^4.2.10",
         "@smithy/middleware-content-length": "^4.2.10",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-retry": "^4.4.37",
+        "@smithy/middleware-endpoint": "^4.4.21",
+        "@smithy/middleware-retry": "^4.4.38",
         "@smithy/middleware-serde": "^4.2.11",
         "@smithy/middleware-stack": "^4.2.10",
         "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/node-http-handler": "^4.4.12",
+        "@smithy/node-http-handler": "^4.4.13",
         "@smithy/protocol-http": "^5.3.10",
-        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/smithy-client": "^4.12.1",
         "@smithy/types": "^4.13.0",
         "@smithy/url-parser": "^4.2.10",
         "@smithy/util-base64": "^4.3.1",
         "@smithy/util-body-length-browser": "^4.2.1",
         "@smithy/util-body-length-node": "^4.2.2",
-        "@smithy/util-defaults-mode-browser": "^4.3.36",
-        "@smithy/util-defaults-mode-node": "^4.2.39",
+        "@smithy/util-defaults-mode-browser": "^4.3.37",
+        "@smithy/util-defaults-mode-node": "^4.2.40",
         "@smithy/util-endpoints": "^3.3.1",
         "@smithy/util-middleware": "^4.2.10",
         "@smithy/util-retry": "^4.2.10",
@@ -944,12 +1016,12 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.5.tgz",
-      "integrity": "sha512-AOitrygDwfTNCLCW7L+GScDy1p49FZ6WutTUFWROouoPetfVNmpL4q8TWD3MhfY/ynhoGhleUQENrBH374EU8w==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.6.tgz",
+      "integrity": "sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/types": "^4.13.0",
@@ -1022,9 +1094,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.3.tgz",
-      "integrity": "sha512-tma6D8/xHZHJEUqmr6ksZjZ0onyIUqKDQLyp50ttZJmS0IwFYzxBgp5CxFvpYAnah52V3UtgrqGA6E83gtT7NQ==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
+      "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -1048,12 +1120,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.2.tgz",
-      "integrity": "sha512-83E6T1CKi0/IozPzqRBKqduW0mS4UQdI3soBH6CG7UgupTADWunqEMOTuPWCs9XGjpJJ4ujj+yu7pn8svhp5yg==",
+      "version": "3.996.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
+      "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/types": "^4.13.0",
         "@smithy/url-parser": "^4.2.10",
         "@smithy/util-endpoints": "^3.3.1",
@@ -1127,25 +1199,25 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.5.tgz",
-      "integrity": "sha512-2ja1WqtuBaEAMgVoHYuWx393DF6ULqdt3OozeO7BosqouYaoU47Adtp9vEF+GImSG/Q8A+dqfwDULTTdMkHGUQ==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.6.tgz",
+      "integrity": "sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/types": "^4.13.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.13.tgz",
-      "integrity": "sha512-PHErmuu+v6iAST48zcsB2cYwDKW45gk6qCp49t1p0NGZ4EaFPr/tA5jl0X/ekDwvWbuT0LTj++fjjdVQAbuh0Q==",
+      "version": "3.973.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.2.tgz",
+      "integrity": "sha512-lpaIuekdkpw7VRiik0IZmd6TyvEUcuLgKZ5fKRGpCA3I4PjrD/XH15sSwW+OptxQjNU4DEzSxag70spC9SluvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.17",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -1185,13 +1257,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.7.tgz",
-      "integrity": "sha512-9GF86s6mHuc1TYCbuKatMDWl2PyK3KIkpRaI7ul2/gYZPfaLzKZ+ISHhxzVb9KVeakf75tUQe6CXW2gugSCXNw==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
+      "integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.3.6",
+        "fast-xml-parser": "5.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2458,9 +2530,9 @@
       ]
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.10.tgz",
-      "integrity": "sha512-qocxM/X4XGATqQtUkbE9SPUB6wekBi+FyJOMbPj0AhvyvFGYEmOlz6VB22iMePCQsFmMIvFSeViDvA7mZJG47g==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -2471,16 +2543,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.9.tgz",
-      "integrity": "sha512-ejQvXqlcU30h7liR9fXtj7PIAau1t/sFbJpgWPfiYDs7zd16jpH0IsSXKcba2jF6ChTXvIjACs27kNMc5xxE2Q==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
+      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-config-provider": "^4.3.11",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-config-provider": "^4.2.1",
-        "@smithy/util-endpoints": "^3.3.1",
-        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2488,20 +2560,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.6.tgz",
-      "integrity": "sha512-4xE+0L2NrsFKpEVFlFELkIHQddBvMbQ41LRIP74dGCXnY1zQ9DgksrBcRBDJT+iOzGy4VEJIeU3hkUK5mn06kg==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.8.tgz",
+      "integrity": "sha512-f7uPeBi7ehmLT4YF2u9j3qx6lSnurG1DLXOsTtJrIRNDF7VXio4BGHQ+SQteN/BrUVudbkuL4v7oOsRCzq4BqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-body-length-browser": "^4.2.1",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-stream": "^4.5.15",
-        "@smithy/util-utf8": "^4.2.1",
-        "@smithy/uuid": "^1.1.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2509,15 +2581,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.10.tgz",
-      "integrity": "sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
+      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/property-provider": "^4.2.10",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
         "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
+        "@smithy/url-parser": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2595,15 +2667,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.11.tgz",
-      "integrity": "sha512-wbTRjOxdFuyEg0CpumjZO0hkUl+fetJFqxNROepuLIoijQh51aMBmzFLfoQdwRjxsuuS2jizzIUTjPWgd8pd7g==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
+      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/querystring-builder": "^4.2.10",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2639,9 +2711,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.1.tgz",
-      "integrity": "sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2665,18 +2737,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.20",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.20.tgz",
-      "integrity": "sha512-9W6Np4ceBP3XCYAGLoMCmn8t2RRVzuD1ndWPLBbv7H9CrwM9Bprf6Up6BM9ZA/3alodg0b7Kf6ftBK9R1N04vw==",
+      "version": "4.4.22",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.22.tgz",
+      "integrity": "sha512-sc81w1o4Jy+/MAQlY3sQ8C7CmSpcvIi3TAzXblUv2hjG11BBSJi/Cw8vDx5BxMxapuH2I+Gc+45vWsgU07WZRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.6",
-        "@smithy/middleware-serde": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/core": "^3.23.8",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.10",
-        "@smithy/util-middleware": "^4.2.10",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2684,19 +2756,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.37",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.37.tgz",
-      "integrity": "sha512-/1psZZllBBSQ7+qo5+hhLz7AEPGLx3Z0+e3ramMBEuPK2PfvLK4SrncDB9VegX5mBn+oP/UTDrM6IHrFjvX1ZA==",
+      "version": "4.4.39",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.39.tgz",
+      "integrity": "sha512-MCVCxaCzuZgiHtHGV2Ke44nh6t4+8/tO+rTYOzrr2+G4nMLU/qbzNCWKBX54lyEaVcGQrfOJiG2f8imtiw+nIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/service-error-classification": "^4.2.10",
-        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.10",
-        "@smithy/util-retry": "^4.2.10",
-        "@smithy/uuid": "^1.1.1",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2704,12 +2776,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.11.tgz",
-      "integrity": "sha512-STQdONGPwbbC7cusL60s7vOa6He6A9w2jWhoapL0mgVjmR19pr26slV+yoSP76SIssMTX/95e5nOZ6UQv6jolg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
+      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -2718,9 +2790,9 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.10.tgz",
-      "integrity": "sha512-pmts/WovNcE/tlyHa8z/groPeOtqtEpp61q3W0nW1nDJuMq/x+hWa/OVQBtgU0tBqupeXq0VBOLA4UZwE8I0YA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
+      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -2731,13 +2803,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.10.tgz",
-      "integrity": "sha512-UALRbJtVX34AdP2VECKVlnNgidLHA2A7YgcJzwSBg1hzmnO/bZBHl/LDQQyYifzUwp1UOODnl9JJ3KNawpUJ9w==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
+      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/shared-ini-file-loader": "^4.4.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -2746,14 +2818,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.12.tgz",
-      "integrity": "sha512-zo1+WKJkR9x7ZtMeMDAAsq2PufwiLDmkhcjpWPRRkmeIuOm6nq1qjFICSZbnjBvD09ei8KMo26BWxsu2BUU+5w==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
-        "@smithy/querystring-builder": "^4.2.10",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -2762,9 +2834,9 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.10.tgz",
-      "integrity": "sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
+      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -2775,9 +2847,9 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.10.tgz",
-      "integrity": "sha512-2NzVWpYY0tRdfeCJLsgrR89KE3NTWT2wGulhNUxYlRmtRmPwLQwKzhrfVaiNlA9ZpJvbW7cjTVChYKgnkqXj1A==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -2788,13 +2860,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.10.tgz",
-      "integrity": "sha512-HeN7kEvuzO2DmAzLukE9UryiUvejD3tMp9a1D1NJETerIfKobBUCLfviP6QEk500166eD2IATaXM59qgUI+YDA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
-        "@smithy/util-uri-escape": "^4.2.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2802,9 +2874,9 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.10.tgz",
-      "integrity": "sha512-4Mh18J26+ao1oX5wXJfWlTT+Q1OpDR8ssiC9PDOuEgVBGloqg18Fw7h5Ct8DyT9NBYwJgtJ2nLjKKFU6RP1G1Q==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
+      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -2815,9 +2887,9 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.10.tgz",
-      "integrity": "sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
+      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0"
@@ -2827,9 +2899,9 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.5.tgz",
-      "integrity": "sha512-pHgASxl50rrtOztgQCPmOXFjRW+mCd7ALr/3uXNzRrRoGV5G2+78GOsQ3HlQuBVHCh9o6xqMNvlIKZjWn4Euug==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
+      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -2859,17 +2931,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.0.tgz",
-      "integrity": "sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.2.tgz",
+      "integrity": "sha512-HezY3UuG0k4T+4xhFKctLXCA5N2oN+Rtv+mmL8Gt7YmsUY2yhmcLyW75qrSzldfj75IsCW/4UhY3s20KcFnZqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.6",
-        "@smithy/middleware-endpoint": "^4.4.20",
-        "@smithy/middleware-stack": "^4.2.10",
-        "@smithy/protocol-http": "^5.3.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-stream": "^4.5.15",
+        "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2889,12 +2961,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.10.tgz",
-      "integrity": "sha512-uypjF7fCDsRk26u3qHmFI/ePL7bxxB9vKkE+2WKEciHhz+4QtbzWiHRVNRJwU3cKhrYDYQE3b0MRFtqfLYdA4A==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
+      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.10",
+        "@smithy/querystring-parser": "^4.2.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -2903,13 +2975,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.1.tgz",
-      "integrity": "sha512-BKGuawX4Doq/bI/uEmg+Zyc36rJKWuin3py89PquXBIBqmbnJwBBsmKhdHfNEp0+A4TDgLmT/3MSKZ1SxHcR6w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2917,9 +2989,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.1.tgz",
-      "integrity": "sha512-SiJeLiozrAoCrgDBUgsVbmqHmMgg/2bA15AzcbcW+zan7SuyAVHN4xTSbq0GlebAIwlcaX32xacnrG488/J/6g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2941,12 +3013,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.1.tgz",
-      "integrity": "sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.1",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2954,9 +3026,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.1.tgz",
-      "integrity": "sha512-462id/00U8JWFw6qBuTSWfN5TxOHvDu4WliI97qOIOnuC/g+NDAknTU8eoGXEPlLkRVgWEr03jJBLV4o2FL8+A==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2966,13 +3038,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.36",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.36.tgz",
-      "integrity": "sha512-R0smq7EHQXRVMxkAxtH5akJ/FvgAmNF6bUy/GwY/N20T4GrwjT633NFm0VuRpC+8Bbv8R9A0DoJ9OiZL/M3xew==",
+      "version": "4.3.38",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.38.tgz",
+      "integrity": "sha512-c8P1mFLNxcsdAMabB8/VUQUbWzFmgujWi4bAXSggcqLYPc8V4U5abqFqOyn+dK4YT+q8UyCVkTO8807t4t2syA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -2981,16 +3053,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.39",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.39.tgz",
-      "integrity": "sha512-otWuoDm35btJV1L8MyHrPl462B07QCdMTktKc7/yM+Psv6KbED/ziXiHnmr7yPHUjfIwE9S8Max0LO24Mo3ZVg==",
+      "version": "4.2.41",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.41.tgz",
+      "integrity": "sha512-/UG+9MT3UZAR0fLzOtMJMfWGcjjHvgggq924x/CRy8vRbL+yFf3Z6vETlvq8vDH92+31P/1gSOFoo7303wN8WQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.9",
-        "@smithy/credential-provider-imds": "^4.2.10",
-        "@smithy/node-config-provider": "^4.3.10",
-        "@smithy/property-provider": "^4.2.10",
-        "@smithy/smithy-client": "^4.12.0",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.2",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -2999,12 +3071,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.1.tgz",
-      "integrity": "sha512-xyctc4klmjmieQiF9I1wssBWleRV0RhJ2DpO8+8yzi2LO1Z+4IWOZNGZGNj4+hq9kdo+nyfrRLmQTzc16Op2Vg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
+      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.10",
+        "@smithy/node-config-provider": "^4.3.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -3013,9 +3085,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.1.tgz",
-      "integrity": "sha512-c1hHtkgAWmE35/50gmdKajgGAKV3ePJ7t6UtEmpfCWJmQE9BQAQPz0URUVI89eSkcDqCtzqllxzG28IQoZPvwA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3025,9 +3097,9 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.10.tgz",
-      "integrity": "sha512-LxaQIWLp4y0r72eA8mwPNQ9va4h5KeLM0I3M/HV9klmFaY2kN766wf5vsTzmaOpNNb7GgXAd9a25P3h8T49PSA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3038,12 +3110,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.10.tgz",
-      "integrity": "sha512-HrBzistfpyE5uqTwiyLsFHscgnwB0kgv8vySp7q5kZ0Eltn/tjosaSGGDj/jJ9ys7pWzIP/icE2d+7vMKXLv7A==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
+      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.10",
+        "@smithy/service-error-classification": "^4.2.11",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -3052,18 +3124,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.15.tgz",
-      "integrity": "sha512-OlOKnaqnkU9X+6wEkd7mN+WB7orPbCVDauXOj22Q7VtiTkvy7ZdSsOg4QiNAZMgI4OkvNf+/VLUC3VXkxuWJZw==",
+      "version": "4.5.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
+      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.11",
-        "@smithy/node-http-handler": "^4.4.12",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
         "@smithy/types": "^4.13.0",
-        "@smithy/util-base64": "^4.3.1",
-        "@smithy/util-buffer-from": "^4.2.1",
-        "@smithy/util-hex-encoding": "^4.2.1",
-        "@smithy/util-utf8": "^4.2.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3071,9 +3143,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.1.tgz",
-      "integrity": "sha512-YmiUDn2eo2IOiWYYvGQkgX5ZkBSiTQu4FlDo5jNPpAxng2t6Sjb6WutnZV9l6VR4eJul1ABmCrnWBC9hKHQa6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3083,12 +3155,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.1.tgz",
-      "integrity": "sha512-DSIwNaWtmzrNQHv8g7DBGR9mulSit65KSj5ymGEIAknmIN8IpbZefEep10LaMG/P/xquwbmJ1h9ectz8z6mV6g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.1",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3110,9 +3182,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.1.tgz",
-      "integrity": "sha512-dSfDCeihDmZlV2oyr0yWPTUfh07suS+R5OB+FZGiv/hHyK3hrFBW5rR1UYjfa57vBsrP9lciFkRPzebaV1Qujw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4115,10 +4187,22 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
       "funding": [
         {
           "type": "github",
@@ -4127,6 +4211,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -5563,9 +5648,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.1002.0",
     "@aws-sdk/client-secrets-manager": "^3.998.0",
     "@strands-agents/sdk": "^0.4.0",
     "bedrock-agentcore": "^0.2.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import { Agent, type AgentResult, BedrockModel } from "@strands-agents/sdk";
 import { BedrockAgentCoreApp } from "bedrock-agentcore/runtime";
 import { z } from "zod";
 import { PrismaAIRSClient } from "./lib/airs-api-client.js";
+import { createCloudWatchStream, createTeeStream } from "./lib/cloudwatch-stream.js";
 import { type Recipe, RecipeSchema } from "./schemas/recipe.js";
 import { fetchUrlTool } from "./tools/fetch-url.js";
 
@@ -191,7 +192,17 @@ export const processHandler = async (
   return recipe;
 };
 
+const LOG_GROUP = "/aws/bedrock/agentcore/recipe-extraction-agent";
+const region = process.env.AWS_REGION || "us-west-2";
+
+/* v8 ignore start -- module-level env branch; tested via deploy */
+const logStream = process.env.BEDROCK_AGENT_ID
+  ? createTeeStream(process.stdout, createCloudWatchStream(LOG_GROUP, region))
+  : process.stdout;
+/* v8 ignore stop */
+
 export const app = new BedrockAgentCoreApp({
+  config: { logging: { options: { stream: logStream } } },
   invocationHandler: {
     requestSchema: z.object({
       url: z.string().url().describe("URL of the recipe page to extract"),

--- a/src/lib/cloudwatch-stream.ts
+++ b/src/lib/cloudwatch-stream.ts
@@ -1,0 +1,93 @@
+import { hostname } from "node:os";
+import { Writable } from "node:stream";
+import {
+  CloudWatchLogsClient,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+const MAX_BATCH = 100;
+const FLUSH_INTERVAL_MS = 1_000;
+
+export function createCloudWatchStream(logGroupName: string, region: string): Writable {
+  const client = new CloudWatchLogsClient({ region });
+  const logStreamName = `${hostname()}-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  let streamCreated = false;
+  let buffer: Array<{ timestamp: number; message: string }> = [];
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  async function ensureStream() {
+    if (streamCreated) return;
+    await client.send(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+    streamCreated = true;
+  }
+
+  async function flush() {
+    if (buffer.length === 0) return;
+    const events = buffer;
+    buffer = [];
+    try {
+      await ensureStream();
+      await client.send(
+        new PutLogEventsCommand({ logGroupName, logStreamName, logEvents: events }),
+      );
+    } catch (err) {
+      process.stdout.write(`[cloudwatch-stream] flush failed: ${err}\n`);
+    }
+  }
+
+  const stream = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      const message = chunk.toString().trimEnd();
+      if (!message) return callback();
+
+      buffer.push({ timestamp: Date.now(), message });
+
+      if (!timer) {
+        timer = setInterval(() => {
+          flush();
+        }, FLUSH_INTERVAL_MS);
+        timer.unref();
+      }
+
+      if (buffer.length >= MAX_BATCH) {
+        flush().then(() => callback(), callback);
+      } else {
+        callback();
+      }
+      return true;
+    },
+    final(callback) {
+      if (timer) clearInterval(timer);
+      flush().then(() => callback(), callback);
+    },
+  });
+
+  return stream;
+}
+
+export function createTeeStream(...streams: Writable[]): Writable {
+  return new Writable({
+    write(chunk, encoding, callback) {
+      let pending = streams.length;
+      let error: Error | null = null;
+      for (const s of streams) {
+        s.write(chunk, encoding, (err) => {
+          if (err && !error) error = err;
+          if (--pending === 0) callback(error);
+        });
+      }
+      return true;
+    },
+    final(callback) {
+      let pending = streams.length;
+      let error: Error | null = null;
+      for (const s of streams) {
+        s.end((err: Error | null) => {
+          if (err && !error) error = err;
+          if (--pending === 0) callback(error);
+        });
+      }
+    },
+  });
+}

--- a/tests/unit/lib/cloudwatch-stream.test.ts
+++ b/tests/unit/lib/cloudwatch-stream.test.ts
@@ -1,0 +1,275 @@
+import { Writable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSend } = vi.hoisted(() => ({
+  mockSend: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@aws-sdk/client-cloudwatch-logs", () => ({
+  CloudWatchLogsClient: class {
+    send = mockSend;
+  },
+  CreateLogStreamCommand: class {
+    constructor(public input: unknown) {}
+  },
+  PutLogEventsCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+import { createCloudWatchStream, createTeeStream } from "../../../src/lib/cloudwatch-stream.js";
+
+describe("createCloudWatchStream", () => {
+  beforeEach(() => {
+    mockSend.mockReset().mockResolvedValue({});
+  });
+
+  it("creates a Writable stream", () => {
+    const stream = createCloudWatchStream("/test/log-group", "us-west-2");
+    expect(stream).toBeInstanceOf(Writable);
+    stream.destroy();
+  });
+
+  it("batches and flushes on stream end", async () => {
+    const stream = createCloudWatchStream("/test/log-group", "us-west-2");
+
+    stream.write('{"level":30,"msg":"hello"}\n');
+    stream.write('{"level":30,"msg":"world"}\n');
+
+    await new Promise<void>((resolve, reject) => {
+      stream.end((err: Error | null) => (err ? reject(err) : resolve()));
+    });
+
+    // CreateLogStream + PutLogEvents
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    const putCmd = mockSend.mock.calls[1][0];
+    expect(putCmd.input.logEvents).toHaveLength(2);
+    expect(putCmd.input.logEvents[0].message).toBe('{"level":30,"msg":"hello"}');
+    expect(putCmd.input.logGroupName).toBe("/test/log-group");
+  });
+
+  it("creates log stream only once", async () => {
+    const stream = createCloudWatchStream("/test/log-group", "us-west-2");
+
+    stream.write("line1\n");
+
+    // Trigger a flush via end
+    await new Promise<void>((resolve, reject) => {
+      stream.end((err: Error | null) => (err ? reject(err) : resolve()));
+    });
+
+    const createCalls = mockSend.mock.calls.filter(
+      (c) => c[0].constructor.name === "CreateLogStreamCommand",
+    );
+    expect(createCalls).toHaveLength(1);
+  });
+
+  it("flushes when batch reaches MAX_BATCH (100)", async () => {
+    const stream = createCloudWatchStream("/test/log-group", "us-west-2");
+
+    const writes: Promise<void>[] = [];
+    for (let i = 0; i < 100; i++) {
+      writes.push(
+        new Promise<void>((resolve, reject) => {
+          stream.write(`line-${i}\n`, (err) => (err ? reject(err) : resolve()));
+        }),
+      );
+    }
+    await Promise.all(writes);
+
+    // Should have flushed: CreateLogStream + PutLogEvents
+    expect(mockSend).toHaveBeenCalledTimes(2);
+
+    await new Promise<void>((resolve, reject) => {
+      stream.end((err: Error | null) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it("handles flush errors gracefully", async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    mockSend.mockRejectedValue(new Error("CW unavailable"));
+
+    const stream = createCloudWatchStream("/test/log-group", "us-west-2");
+    stream.write("test\n");
+
+    await new Promise<void>((resolve, reject) => {
+      stream.end((err: Error | null) => (err ? reject(err) : resolve()));
+    });
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining("flush failed"));
+    stdoutSpy.mockRestore();
+  });
+
+  it("skips empty messages", async () => {
+    const stream = createCloudWatchStream("/test/log-group", "us-west-2");
+
+    await new Promise<void>((resolve, reject) => {
+      stream.write("\n", (err) => (err ? reject(err) : resolve()));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      stream.end((err: Error | null) => (err ? reject(err) : resolve()));
+    });
+
+    // No CW calls since only empty message + empty flush
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("skips CreateLogStream on subsequent flushes", async () => {
+    vi.useFakeTimers();
+    const stream = createCloudWatchStream("/test/log-group", "us-west-2");
+
+    stream.write("line1\n");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    stream.write("line2\n");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const createCalls = mockSend.mock.calls.filter(
+      (c) => c[0].constructor.name === "CreateLogStreamCommand",
+    );
+    expect(createCalls).toHaveLength(1);
+    // Two PutLogEvents calls
+    const putCalls = mockSend.mock.calls.filter(
+      (c) => c[0].constructor.name === "PutLogEventsCommand",
+    );
+    expect(putCalls).toHaveLength(2);
+
+    stream.destroy();
+    vi.useRealTimers();
+  });
+
+  it("flushes periodically via interval", async () => {
+    vi.useFakeTimers();
+    const stream = createCloudWatchStream("/test/log-group", "us-west-2");
+
+    stream.write("line1\n");
+    expect(mockSend).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    // CreateLogStream + PutLogEvents
+    expect(mockSend).toHaveBeenCalledTimes(2);
+
+    stream.destroy();
+    vi.useRealTimers();
+  });
+});
+
+describe("createTeeStream", () => {
+  it("writes to all underlying streams", async () => {
+    const chunks1: string[] = [];
+    const chunks2: string[] = [];
+
+    const s1 = new Writable({
+      write(chunk, _enc, cb) {
+        chunks1.push(chunk.toString());
+        cb();
+      },
+    });
+    const s2 = new Writable({
+      write(chunk, _enc, cb) {
+        chunks2.push(chunk.toString());
+        cb();
+      },
+    });
+
+    const tee = createTeeStream(s1, s2);
+    tee.write("hello");
+
+    await new Promise<void>((resolve, reject) => {
+      tee.end((err: Error | null) => (err ? reject(err) : resolve()));
+    });
+
+    expect(chunks1).toEqual(["hello"]);
+    expect(chunks2).toEqual(["hello"]);
+  });
+
+  it("propagates errors from underlying streams", async () => {
+    const failing = new Writable({
+      write(_chunk, _enc, cb) {
+        cb(new Error("write failed"));
+      },
+    });
+    failing.on("error", () => {}); // prevent uncaught exception
+
+    const ok = new Writable({
+      write(_chunk, _enc, cb) {
+        cb();
+      },
+    });
+
+    const tee = createTeeStream(ok, failing);
+    tee.on("error", () => {}); // prevent uncaught exception
+
+    await new Promise<void>((resolve) => {
+      tee.write("test", (err) => {
+        expect(err?.message).toBe("write failed");
+        resolve();
+      });
+    });
+
+    tee.destroy();
+  });
+
+  it("propagates errors from underlying stream final", async () => {
+    const s1 = new Writable({
+      write(_chunk, _enc, cb) {
+        cb();
+      },
+      final(cb) {
+        cb(new Error("final failed"));
+      },
+    });
+    s1.on("error", () => {}); // prevent uncaught exception
+    const s2 = new Writable({
+      write(_chunk, _enc, cb) {
+        cb();
+      },
+      final(cb) {
+        cb();
+      },
+    });
+
+    const tee = createTeeStream(s1, s2);
+    tee.on("error", () => {}); // prevent uncaught exception
+
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        tee.end((err: Error | null) => (err ? reject(err) : resolve()));
+      }),
+    ).rejects.toThrow("final failed");
+  });
+
+  it("calls end on all underlying streams in final", async () => {
+    const ended: string[] = [];
+
+    const s1 = new Writable({
+      write(_chunk, _enc, cb) {
+        cb();
+      },
+      final(cb) {
+        ended.push("s1");
+        cb();
+      },
+    });
+    const s2 = new Writable({
+      write(_chunk, _enc, cb) {
+        cb();
+      },
+      final(cb) {
+        ended.push("s2");
+        cb();
+      },
+    });
+
+    const tee = createTeeStream(s1, s2);
+
+    await new Promise<void>((resolve, reject) => {
+      tee.end((err: Error | null) => (err ? reject(err) : resolve()));
+    });
+
+    expect(ended).toContain("s1");
+    expect(ended).toContain("s2");
+  });
+});


### PR DESCRIPTION
## Summary
- Reverts removal from #10 — AgentCore platform does NOT capture container stdout to CloudWatch
- The custom `createCloudWatchStream` + tee stream is the only mechanism delivering app logs
- Restores `@aws-sdk/client-cloudwatch-logs` dependency

## Test plan
- [x] 108 tests pass, 100% coverage
- [ ] Deploy with `scripts/deploy.sh --update` and verify logs in CloudWatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)