### PR TITLE
feat: accept plain text prompt for LiteLLM compatibility

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,6 +55,13 @@ export const agent = new Agent({
   printer: false,
 });
 
+const URL_REGEX = /https?:\/\/[^\s"'<>]+/;
+
+export function extractUrl(text: string): string | null {
+  const match = text.match(URL_REGEX);
+  return match ? match[0] : null;
+}
+
 export function extractJson(text: string): unknown {
   // Try direct parse first
   try {
@@ -141,7 +148,7 @@ function scanErrorFields(err: unknown) {
 }
 
 export const processHandler = async (
-  request: { url: string },
+  request: { url?: string; prompt?: string },
   context: {
     sessionId: string;
     log: {
@@ -152,9 +159,21 @@ export const processHandler = async (
   },
 ) => {
   const start = Date.now();
-  context.log.info({ url: request.url, sessionId: context.sessionId }, "Extracting recipe");
 
-  const prompt = `Extract the recipe from this URL: ${request.url}`;
+  // Accept {"url": "..."} or {"prompt": "natural language with URL"}
+  let url = request.url;
+  if (!url && request.prompt) {
+    url = extractUrl(request.prompt) ?? undefined;
+  }
+  if (!url) {
+    throw new Error(
+      'No URL found in request. Provide {"url": "..."} or a prompt containing a URL.',
+    );
+  }
+
+  context.log.info({ url, sessionId: context.sessionId }, "Extracting recipe");
+
+  const prompt = `Extract the recipe from this URL: ${url}`;
 
   context.log.info({ airsEnabled, airsProfileName: airsProfileName || null }, "AIRS SDK status");
 
@@ -302,7 +321,8 @@ export const app = new BedrockAgentCoreApp({
   config: { logging: { options: { stream: logStream } } },
   invocationHandler: {
     requestSchema: z.object({
-      url: z.string().url().describe("URL of the recipe page to extract"),
+      url: z.string().url().describe("URL of the recipe page to extract").optional(),
+      prompt: z.string().describe("Natural language prompt containing a recipe URL").optional(),
     }),
     process: processHandler,
   },

--- a/tests/integration/process-handler.test.ts
+++ b/tests/integration/process-handler.test.ts
@@ -438,6 +438,46 @@ describe("processHandler", () => {
     });
   });
 
+  describe("prompt-based input (LiteLLM compatibility)", () => {
+    it("extracts URL from prompt field", async () => {
+      mockInvoke.mockResolvedValueOnce(mockAgentResult(JSON.stringify(validRecipe)));
+
+      const result = await processHandler(
+        { prompt: "Extract the recipe from https://example.com/recipe" },
+        mockContext(),
+      );
+
+      expect(result).toEqual(validRecipe);
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "Extract the recipe from this URL: https://example.com/recipe",
+      );
+    });
+
+    it("prefers url field over prompt field", async () => {
+      mockInvoke.mockResolvedValueOnce(mockAgentResult(JSON.stringify(validRecipe)));
+
+      const result = await processHandler(
+        { url: "https://example.com/a", prompt: "get https://example.com/b" },
+        mockContext(),
+      );
+
+      expect(result).toEqual(validRecipe);
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "Extract the recipe from this URL: https://example.com/a",
+      );
+    });
+
+    it("throws when prompt has no URL", async () => {
+      await expect(
+        processHandler({ prompt: "make me a recipe for pasta" }, mockContext()),
+      ).rejects.toThrow("No URL found in request");
+    });
+
+    it("throws when neither url nor prompt provided", async () => {
+      await expect(processHandler({}, mockContext())).rejects.toThrow("No URL found in request");
+    });
+  });
+
   it("skips AIRS scans when disabled", async () => {
     mockInvoke.mockResolvedValueOnce(mockAgentResult(JSON.stringify(validRecipe)));
 

--- a/tests/unit/extract-json.test.ts
+++ b/tests/unit/extract-json.test.ts
@@ -16,7 +16,7 @@ vi.mock("bedrock-agentcore/runtime", () => ({
   },
 }));
 
-import { extractJson } from "../../src/app.js";
+import { extractJson, extractUrl } from "../../src/app.js";
 
 describe("extractJson", () => {
   describe("tier 1: direct JSON.parse", () => {
@@ -94,5 +94,41 @@ describe("extractJson", () => {
       const input = '{"a":1}';
       expect(extractJson(input)).toEqual({ a: 1 });
     });
+  });
+});
+
+describe("extractUrl", () => {
+  it("extracts URL from natural language", () => {
+    expect(extractUrl("Extract the recipe from https://example.com/recipe please")).toBe(
+      "https://example.com/recipe",
+    );
+  });
+
+  it("extracts URL with path and query params", () => {
+    expect(extractUrl("Get https://example.com/recipe?id=123&lang=en")).toBe(
+      "https://example.com/recipe?id=123&lang=en",
+    );
+  });
+
+  it("extracts http URL", () => {
+    expect(extractUrl("try http://example.com/page")).toBe("http://example.com/page");
+  });
+
+  it("returns first URL when multiple present", () => {
+    expect(extractUrl("compare https://a.com and https://b.com")).toBe("https://a.com");
+  });
+
+  it("returns null when no URL present", () => {
+    expect(extractUrl("just some text with no links")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractUrl("")).toBeNull();
+  });
+
+  it("extracts bare URL", () => {
+    expect(extractUrl("https://pinchofyum.com/chicken-wontons")).toBe(
+      "https://pinchofyum.com/chicken-wontons",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Agent now accepts `{"prompt": "..."}` in addition to `{"url": "..."}`
- Extracts URL from natural language via regex (`extractUrl()`)
- `url` field takes priority when both are provided
- Throws clear error when no URL found in either field
- Enables LiteLLM gateway integration without client-side payload transformation

## Test plan

- [x] 110 tests pass locally, 100% coverage
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)