### PR TITLE
fix: 500 errors from LiteLLM — error objects + fetch headers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -157,7 +157,7 @@ export const processHandler = async (
       error: (obj: unknown, msg: string) => void;
     };
   },
-) => {
+): Promise<Recipe | { error: string; message: string; [key: string]: unknown }> => {
   const start = Date.now();
 
   // Accept {"url": "..."} or {"prompt": "natural language with URL"}
@@ -166,9 +166,10 @@ export const processHandler = async (
     url = extractUrl(request.prompt) ?? undefined;
   }
   if (!url) {
-    throw new Error(
-      'No URL found in request. Provide {"url": "..."} or a prompt containing a URL.',
-    );
+    return {
+      error: "bad_request",
+      message: 'No URL found in request. Provide {"url": "..."} or a prompt containing a URL.',
+    };
   }
 
   context.log.info({ url, sessionId: context.sessionId }, "Extracting recipe");
@@ -230,7 +231,7 @@ export const processHandler = async (
       { error: String(err), durationMs: Date.now() - agentStart },
       "Agent invocation failed",
     );
-    throw err;
+    return { error: "agent_error", message: `Agent invocation failed: ${String(err)}` };
   }
 
   const agentDurationMs = Date.now() - agentStart;
@@ -248,7 +249,7 @@ export const processHandler = async (
       { error: String(err), responsePreview: responseText.slice(0, 200) },
       "Failed to parse recipe from agent response",
     );
-    throw err;
+    return { error: "parse_error", message: `Failed to parse recipe: ${String(err)}` };
   }
 
   context.log.info(

--- a/src/tools/fetch-url.ts
+++ b/src/tools/fetch-url.ts
@@ -25,9 +25,18 @@ export const fetchUrlTool = tool({
     const response = await fetch(input.url, {
       headers: {
         "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+        Accept:
+          "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
         "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Cache-Control": "no-cache",
+        Pragma: "no-cache",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "Upgrade-Insecure-Requests": "1",
       },
       redirect: "follow",
     });

--- a/tests/integration/process-handler.test.ts
+++ b/tests/integration/process-handler.test.ts
@@ -115,35 +115,43 @@ describe("processHandler", () => {
     expect(result).toEqual(validRecipe);
   });
 
-  it("throws and logs when agent invocation fails", async () => {
+  it("returns error object when agent invocation fails", async () => {
     mockInvoke.mockRejectedValueOnce(new Error("Model timeout"));
 
     const ctx = mockContext();
-    await expect(processHandler({ url: "https://example.com/recipe" }, ctx)).rejects.toThrow(
-      "Model timeout",
-    );
+    const result = await processHandler({ url: "https://example.com/recipe" }, ctx);
 
+    expect(result).toEqual({
+      error: "agent_error",
+      message: expect.stringContaining("Model timeout"),
+    });
     expect(ctx.log.error).toHaveBeenCalledWith(
       expect.objectContaining({ error: "Error: Model timeout" }),
       "Agent invocation failed",
     );
   });
 
-  it("throws when agent returns no JSON", async () => {
+  it("returns error object when agent returns no JSON", async () => {
     mockInvoke.mockResolvedValueOnce(mockAgentResult("I could not find a recipe on that page."));
 
-    await expect(
-      processHandler({ url: "https://example.com/recipe" }, mockContext()),
-    ).rejects.toThrow("Could not extract JSON from agent response");
+    const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
+
+    expect(result).toEqual({
+      error: "parse_error",
+      message: expect.stringContaining("Could not extract JSON"),
+    });
   });
 
-  it("throws when JSON fails schema validation", async () => {
+  it("returns error object when JSON fails schema validation", async () => {
     const invalid = { title: "Missing fields" }; // no ingredients, etc.
     mockInvoke.mockResolvedValueOnce(mockAgentResult(JSON.stringify(invalid)));
 
-    await expect(
-      processHandler({ url: "https://example.com/recipe" }, mockContext()),
-    ).rejects.toThrow();
+    const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
+
+    expect(result).toEqual({
+      error: "parse_error",
+      message: expect.stringContaining("Failed to parse recipe"),
+    });
   });
 
   it("calls agent.invoke with correct prompt", async () => {
@@ -467,14 +475,22 @@ describe("processHandler", () => {
       );
     });
 
-    it("throws when prompt has no URL", async () => {
-      await expect(
-        processHandler({ prompt: "make me a recipe for pasta" }, mockContext()),
-      ).rejects.toThrow("No URL found in request");
+    it("returns error when prompt has no URL", async () => {
+      const result = await processHandler({ prompt: "make me a recipe for pasta" }, mockContext());
+
+      expect(result).toEqual({
+        error: "bad_request",
+        message: expect.stringContaining("No URL found"),
+      });
     });
 
-    it("throws when neither url nor prompt provided", async () => {
-      await expect(processHandler({}, mockContext())).rejects.toThrow("No URL found in request");
+    it("returns error when neither url nor prompt provided", async () => {
+      const result = await processHandler({}, mockContext());
+
+      expect(result).toEqual({
+        error: "bad_request",
+        message: expect.stringContaining("No URL found"),
+      });
     });
   });
 

--- a/tests/unit/tools/fetch-url.test.ts
+++ b/tests/unit/tools/fetch-url.test.ts
@@ -212,11 +212,13 @@ describe("fetchUrlTool", () => {
       await fetchUrlTool.invoke({ url: "https://example.com" });
 
       expect(mockFetch).toHaveBeenCalledWith("https://example.com", {
-        headers: {
+        headers: expect.objectContaining({
           "User-Agent": expect.stringContaining("Mozilla/5.0"),
           Accept: expect.stringContaining("text/html"),
           "Accept-Language": "en-US,en;q=0.9",
-        },
+          "Sec-Fetch-Dest": "document",
+          "Sec-Fetch-Mode": "navigate",
+        }),
         redirect: "follow",
       });
     });


### PR DESCRIPTION
## Summary

- **Bug 1**: Updated fetch headers to Chrome 136 with `Sec-Fetch-*`, `Cache-Control`, `Accept-Encoding` — fixes 402 blocks from Allrecipes and similar sites
- **Bug 2**: Error paths now return `{error, message}` objects instead of throwing — prevents Fastify crash (`payload of invalid type 'object'`) in `_handleInvocation`

Error response shapes:
- `{"error": "bad_request", "message": "No URL found..."}` — no URL in request
- `{"error": "agent_error", "message": "Agent invocation failed: ..."}` — Bedrock call failed
- `{"error": "parse_error", "message": "Failed to parse recipe: ..."}` — JSON extraction/validation failed

## Test plan

- [x] 110 tests pass locally, 100% coverage
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)