### PR TITLE
fix: stringify handler response for LiteLLM compatibility

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -157,7 +157,7 @@ export const processHandler = async (
       error: (obj: unknown, msg: string) => void;
     };
   },
-): Promise<Recipe | { error: string; message: string; [key: string]: unknown }> => {
+): Promise<string> => {
   const start = Date.now();
 
   // Accept {"url": "..."} or {"prompt": "natural language with URL"}
@@ -166,10 +166,10 @@ export const processHandler = async (
     url = extractUrl(request.prompt) ?? undefined;
   }
   if (!url) {
-    return {
+    return JSON.stringify({
       error: "bad_request",
       message: 'No URL found in request. Provide {"url": "..."} or a prompt containing a URL.',
-    };
+    });
   }
 
   context.log.info({ url, sessionId: context.sessionId }, "Extracting recipe");
@@ -208,12 +208,12 @@ export const processHandler = async (
         { category: promptScan.category, scanId: promptScan.scan_id },
         "Request blocked by AIRS",
       );
-      return {
+      return JSON.stringify({
         error: "blocked",
         message: "Request blocked by Prisma AIRS security.",
         category: promptScan.category,
         scan_id: promptScan.scan_id,
-      };
+      });
     }
   }
 
@@ -231,7 +231,10 @@ export const processHandler = async (
       { error: String(err), durationMs: Date.now() - agentStart },
       "Agent invocation failed",
     );
-    return { error: "agent_error", message: `Agent invocation failed: ${String(err)}` };
+    return JSON.stringify({
+      error: "agent_error",
+      message: `Agent invocation failed: ${String(err)}`,
+    });
   }
 
   const agentDurationMs = Date.now() - agentStart;
@@ -249,7 +252,10 @@ export const processHandler = async (
       { error: String(err), responsePreview: responseText.slice(0, 200) },
       "Failed to parse recipe from agent response",
     );
-    return { error: "parse_error", message: `Failed to parse recipe: ${String(err)}` };
+    return JSON.stringify({
+      error: "parse_error",
+      message: `Failed to parse recipe: ${String(err)}`,
+    });
   }
 
   context.log.info(
@@ -294,19 +300,19 @@ export const processHandler = async (
         { category: responseScan.category, scanId: responseScan.scan_id },
         "Response blocked by AIRS",
       );
-      return {
+      return JSON.stringify({
         error: "blocked",
         message: "Response blocked by Prisma AIRS security.",
         category: responseScan.category,
         scan_id: responseScan.scan_id,
-      };
+      });
     }
   }
 
   const totalDurationMs = Date.now() - start;
   context.log.info({ totalDurationMs, title: recipe.title }, "Request complete");
 
-  return recipe;
+  return JSON.stringify(recipe);
 };
 
 const LOG_GROUP = "/aws/bedrock/agentcore/recipe-extraction-agent";

--- a/tests/integration/process-handler.test.ts
+++ b/tests/integration/process-handler.test.ts
@@ -92,7 +92,7 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(result).toEqual(validRecipe);
+    expect(JSON.parse(result)).toEqual(validRecipe);
   });
 
   it("handles markdown-wrapped JSON response", async () => {
@@ -102,7 +102,7 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(result).toEqual(validRecipe);
+    expect(JSON.parse(result)).toEqual(validRecipe);
   });
 
   it("handles JSON with surrounding text", async () => {
@@ -112,7 +112,7 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(result).toEqual(validRecipe);
+    expect(JSON.parse(result)).toEqual(validRecipe);
   });
 
   it("returns error object when agent invocation fails", async () => {
@@ -121,10 +121,9 @@ describe("processHandler", () => {
     const ctx = mockContext();
     const result = await processHandler({ url: "https://example.com/recipe" }, ctx);
 
-    expect(result).toEqual({
-      error: "agent_error",
-      message: expect.stringContaining("Model timeout"),
-    });
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toBe("agent_error");
+    expect(parsed.message).toContain("Model timeout");
     expect(ctx.log.error).toHaveBeenCalledWith(
       expect.objectContaining({ error: "Error: Model timeout" }),
       "Agent invocation failed",
@@ -136,10 +135,9 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(result).toEqual({
-      error: "parse_error",
-      message: expect.stringContaining("Could not extract JSON"),
-    });
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toBe("parse_error");
+    expect(parsed.message).toContain("Could not extract JSON");
   });
 
   it("returns error object when JSON fails schema validation", async () => {
@@ -148,10 +146,9 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(result).toEqual({
-      error: "parse_error",
-      message: expect.stringContaining("Failed to parse recipe"),
-    });
+    const parsed = JSON.parse(result);
+    expect(parsed.error).toBe("parse_error");
+    expect(parsed.message).toContain("Failed to parse recipe");
   });
 
   it("calls agent.invoke with correct prompt", async () => {
@@ -202,7 +199,7 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(result).toEqual(fullRecipe);
+    expect(JSON.parse(result)).toEqual(fullRecipe);
   });
 
   describe("AIRS integration", () => {
@@ -320,7 +317,7 @@ describe("processHandler", () => {
       const { processHandler: handler } = await import("../../src/app.js");
       const result = await handler({ url: "https://example.com/recipe" }, mockContext());
 
-      expect(result).toEqual({
+      expect(JSON.parse(result)).toEqual({
         error: "blocked",
         message: "Request blocked by Prisma AIRS security.",
         category: "injection",
@@ -337,7 +334,7 @@ describe("processHandler", () => {
       const ctx = mockContext();
       const result = await handler({ url: "https://example.com/recipe" }, ctx);
 
-      expect(result).toEqual(validRecipe);
+      expect(JSON.parse(result)).toEqual(validRecipe);
       expect(ctx.log.error).toHaveBeenCalledWith(
         expect.objectContaining({ err: expect.stringContaining("AIRS timeout") }),
         "AIRS prompt scan failed, proceeding unscanned",
@@ -392,7 +389,7 @@ describe("processHandler", () => {
       const ctx = mockContext();
       const result = await handler({ url: "https://example.com/recipe" }, ctx);
 
-      expect(result).toEqual(validRecipe);
+      expect(JSON.parse(result)).toEqual(validRecipe);
       expect(ctx.log.error).toHaveBeenCalledWith(
         expect.objectContaining({ err: expect.stringContaining("AIRS timeout") }),
         "AIRS response scan failed, proceeding unscanned",
@@ -437,7 +434,7 @@ describe("processHandler", () => {
       const { processHandler: handler } = await import("../../src/app.js");
       const result = await handler({ url: "https://example.com/recipe" }, mockContext());
 
-      expect(result).toEqual({
+      expect(JSON.parse(result)).toEqual({
         error: "blocked",
         message: "Response blocked by Prisma AIRS security.",
         category: "dlp",
@@ -455,7 +452,7 @@ describe("processHandler", () => {
         mockContext(),
       );
 
-      expect(result).toEqual(validRecipe);
+      expect(JSON.parse(result)).toEqual(validRecipe);
       expect(mockInvoke).toHaveBeenCalledWith(
         "Extract the recipe from this URL: https://example.com/recipe",
       );
@@ -469,7 +466,7 @@ describe("processHandler", () => {
         mockContext(),
       );
 
-      expect(result).toEqual(validRecipe);
+      expect(JSON.parse(result)).toEqual(validRecipe);
       expect(mockInvoke).toHaveBeenCalledWith(
         "Extract the recipe from this URL: https://example.com/a",
       );
@@ -478,19 +475,17 @@ describe("processHandler", () => {
     it("returns error when prompt has no URL", async () => {
       const result = await processHandler({ prompt: "make me a recipe for pasta" }, mockContext());
 
-      expect(result).toEqual({
-        error: "bad_request",
-        message: expect.stringContaining("No URL found"),
-      });
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toBe("bad_request");
+      expect(parsed.message).toContain("No URL found");
     });
 
     it("returns error when neither url nor prompt provided", async () => {
       const result = await processHandler({}, mockContext());
 
-      expect(result).toEqual({
-        error: "bad_request",
-        message: expect.stringContaining("No URL found"),
-      });
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toBe("bad_request");
+      expect(parsed.message).toContain("No URL found");
     });
   });
 


### PR DESCRIPTION
## Summary

- `processHandler` now returns `JSON.stringify(...)` strings instead of raw objects
- LiteLLM's AgentCore parser expects a text string to populate `choices[0].message.content`
- Raw objects caused empty `"content":""` in LiteLLM responses

## Test plan

- [x] 110 tests pass locally, 100% coverage
- [ ] CI passes
- [ ] Verify via LiteLLM gateway that recipe content appears in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)