### PR TITLE
revert: undo stringify handler response (#17)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -157,7 +157,7 @@ export const processHandler = async (
       error: (obj: unknown, msg: string) => void;
     };
   },
-): Promise<string> => {
+): Promise<Recipe | { error: string; message: string; [key: string]: unknown }> => {
   const start = Date.now();
 
   // Accept {"url": "..."} or {"prompt": "natural language with URL"}
@@ -166,10 +166,10 @@ export const processHandler = async (
     url = extractUrl(request.prompt) ?? undefined;
   }
   if (!url) {
-    return JSON.stringify({
+    return {
       error: "bad_request",
       message: 'No URL found in request. Provide {"url": "..."} or a prompt containing a URL.',
-    });
+    };
   }
 
   context.log.info({ url, sessionId: context.sessionId }, "Extracting recipe");
@@ -208,12 +208,12 @@ export const processHandler = async (
         { category: promptScan.category, scanId: promptScan.scan_id },
         "Request blocked by AIRS",
       );
-      return JSON.stringify({
+      return {
         error: "blocked",
         message: "Request blocked by Prisma AIRS security.",
         category: promptScan.category,
         scan_id: promptScan.scan_id,
-      });
+      };
     }
   }
 
@@ -231,10 +231,7 @@ export const processHandler = async (
       { error: String(err), durationMs: Date.now() - agentStart },
       "Agent invocation failed",
     );
-    return JSON.stringify({
-      error: "agent_error",
-      message: `Agent invocation failed: ${String(err)}`,
-    });
+    return { error: "agent_error", message: `Agent invocation failed: ${String(err)}` };
   }
 
   const agentDurationMs = Date.now() - agentStart;
@@ -252,10 +249,7 @@ export const processHandler = async (
       { error: String(err), responsePreview: responseText.slice(0, 200) },
       "Failed to parse recipe from agent response",
     );
-    return JSON.stringify({
-      error: "parse_error",
-      message: `Failed to parse recipe: ${String(err)}`,
-    });
+    return { error: "parse_error", message: `Failed to parse recipe: ${String(err)}` };
   }
 
   context.log.info(
@@ -300,19 +294,19 @@ export const processHandler = async (
         { category: responseScan.category, scanId: responseScan.scan_id },
         "Response blocked by AIRS",
       );
-      return JSON.stringify({
+      return {
         error: "blocked",
         message: "Response blocked by Prisma AIRS security.",
         category: responseScan.category,
         scan_id: responseScan.scan_id,
-      });
+      };
     }
   }
 
   const totalDurationMs = Date.now() - start;
   context.log.info({ totalDurationMs, title: recipe.title }, "Request complete");
 
-  return JSON.stringify(recipe);
+  return recipe;
 };
 
 const LOG_GROUP = "/aws/bedrock/agentcore/recipe-extraction-agent";

--- a/tests/integration/process-handler.test.ts
+++ b/tests/integration/process-handler.test.ts
@@ -92,7 +92,7 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(JSON.parse(result)).toEqual(validRecipe);
+    expect(result).toEqual(validRecipe);
   });
 
   it("handles markdown-wrapped JSON response", async () => {
@@ -102,7 +102,7 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(JSON.parse(result)).toEqual(validRecipe);
+    expect(result).toEqual(validRecipe);
   });
 
   it("handles JSON with surrounding text", async () => {
@@ -112,7 +112,7 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(JSON.parse(result)).toEqual(validRecipe);
+    expect(result).toEqual(validRecipe);
   });
 
   it("returns error object when agent invocation fails", async () => {
@@ -121,9 +121,10 @@ describe("processHandler", () => {
     const ctx = mockContext();
     const result = await processHandler({ url: "https://example.com/recipe" }, ctx);
 
-    const parsed = JSON.parse(result);
-    expect(parsed.error).toBe("agent_error");
-    expect(parsed.message).toContain("Model timeout");
+    expect(result).toEqual({
+      error: "agent_error",
+      message: expect.stringContaining("Model timeout"),
+    });
     expect(ctx.log.error).toHaveBeenCalledWith(
       expect.objectContaining({ error: "Error: Model timeout" }),
       "Agent invocation failed",
@@ -135,9 +136,10 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    const parsed = JSON.parse(result);
-    expect(parsed.error).toBe("parse_error");
-    expect(parsed.message).toContain("Could not extract JSON");
+    expect(result).toEqual({
+      error: "parse_error",
+      message: expect.stringContaining("Could not extract JSON"),
+    });
   });
 
   it("returns error object when JSON fails schema validation", async () => {
@@ -146,9 +148,10 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    const parsed = JSON.parse(result);
-    expect(parsed.error).toBe("parse_error");
-    expect(parsed.message).toContain("Failed to parse recipe");
+    expect(result).toEqual({
+      error: "parse_error",
+      message: expect.stringContaining("Failed to parse recipe"),
+    });
   });
 
   it("calls agent.invoke with correct prompt", async () => {
@@ -199,7 +202,7 @@ describe("processHandler", () => {
 
     const result = await processHandler({ url: "https://example.com/recipe" }, mockContext());
 
-    expect(JSON.parse(result)).toEqual(fullRecipe);
+    expect(result).toEqual(fullRecipe);
   });
 
   describe("AIRS integration", () => {
@@ -317,7 +320,7 @@ describe("processHandler", () => {
       const { processHandler: handler } = await import("../../src/app.js");
       const result = await handler({ url: "https://example.com/recipe" }, mockContext());
 
-      expect(JSON.parse(result)).toEqual({
+      expect(result).toEqual({
         error: "blocked",
         message: "Request blocked by Prisma AIRS security.",
         category: "injection",
@@ -334,7 +337,7 @@ describe("processHandler", () => {
       const ctx = mockContext();
       const result = await handler({ url: "https://example.com/recipe" }, ctx);
 
-      expect(JSON.parse(result)).toEqual(validRecipe);
+      expect(result).toEqual(validRecipe);
       expect(ctx.log.error).toHaveBeenCalledWith(
         expect.objectContaining({ err: expect.stringContaining("AIRS timeout") }),
         "AIRS prompt scan failed, proceeding unscanned",
@@ -389,7 +392,7 @@ describe("processHandler", () => {
       const ctx = mockContext();
       const result = await handler({ url: "https://example.com/recipe" }, ctx);
 
-      expect(JSON.parse(result)).toEqual(validRecipe);
+      expect(result).toEqual(validRecipe);
       expect(ctx.log.error).toHaveBeenCalledWith(
         expect.objectContaining({ err: expect.stringContaining("AIRS timeout") }),
         "AIRS response scan failed, proceeding unscanned",
@@ -434,7 +437,7 @@ describe("processHandler", () => {
       const { processHandler: handler } = await import("../../src/app.js");
       const result = await handler({ url: "https://example.com/recipe" }, mockContext());
 
-      expect(JSON.parse(result)).toEqual({
+      expect(result).toEqual({
         error: "blocked",
         message: "Response blocked by Prisma AIRS security.",
         category: "dlp",
@@ -452,7 +455,7 @@ describe("processHandler", () => {
         mockContext(),
       );
 
-      expect(JSON.parse(result)).toEqual(validRecipe);
+      expect(result).toEqual(validRecipe);
       expect(mockInvoke).toHaveBeenCalledWith(
         "Extract the recipe from this URL: https://example.com/recipe",
       );
@@ -466,7 +469,7 @@ describe("processHandler", () => {
         mockContext(),
       );
 
-      expect(JSON.parse(result)).toEqual(validRecipe);
+      expect(result).toEqual(validRecipe);
       expect(mockInvoke).toHaveBeenCalledWith(
         "Extract the recipe from this URL: https://example.com/a",
       );
@@ -475,17 +478,19 @@ describe("processHandler", () => {
     it("returns error when prompt has no URL", async () => {
       const result = await processHandler({ prompt: "make me a recipe for pasta" }, mockContext());
 
-      const parsed = JSON.parse(result);
-      expect(parsed.error).toBe("bad_request");
-      expect(parsed.message).toContain("No URL found");
+      expect(result).toEqual({
+        error: "bad_request",
+        message: expect.stringContaining("No URL found"),
+      });
     });
 
     it("returns error when neither url nor prompt provided", async () => {
       const result = await processHandler({}, mockContext());
 
-      const parsed = JSON.parse(result);
-      expect(parsed.error).toBe("bad_request");
-      expect(parsed.message).toContain("No URL found");
+      expect(result).toEqual({
+        error: "bad_request",
+        message: expect.stringContaining("No URL found"),
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Reverts #17. Stringifying the response didn't fix LiteLLM compatibility — the issue is in LiteLLM's AgentCore response parser, not our response format. The stringify change broke clean JSON output for direct callers (AWS CLI, curl).

## Test plan

- [x] 110 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)