### PR TITLE
fix: make notes optional in RecipeSchema

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -25,7 +25,7 @@ export const SYSTEM_PROMPT = `You are a recipe extraction agent. When given a UR
   ],
   "preparationSteps": ["string"],
   "cookingSteps": ["string"],
-  "notes": {
+  "notes": {  // optional — omit entirely if no metadata available
     "servings": "string or omit",
     "cookTime": "string or omit",
     "prepTime": "string or omit",

--- a/src/schemas/recipe.ts
+++ b/src/schemas/recipe.ts
@@ -26,6 +26,7 @@ export const RecipeSchema = z.object({
       prepTime: z.string().optional().describe("Preparation time (e.g. '15 minutes')"),
       tips: z.array(z.string()).optional().describe("Additional tips or notes from the recipe"),
     })
+    .optional()
     .describe("Recipe metadata and tips"),
 });
 

--- a/tests/unit/schemas/recipe.test.ts
+++ b/tests/unit/schemas/recipe.test.ts
@@ -113,9 +113,9 @@ describe("RecipeSchema", () => {
     expect(() => RecipeSchema.parse(rest)).toThrow();
   });
 
-  it("rejects missing notes", () => {
+  it("accepts recipe without notes field", () => {
     const { notes, ...rest } = validRecipe;
-    expect(() => RecipeSchema.parse(rest)).toThrow();
+    expect(RecipeSchema.parse(rest)).toEqual(rest);
   });
 
   it("rejects invalid ingredient in array", () => {


### PR DESCRIPTION
## Summary
- Make `notes` field `.optional()` in `RecipeSchema` to match system prompt "or omit" language
- Add system prompt comment clarifying notes is optional
- Update test: "rejects missing notes" → "accepts recipe without notes field"

Closes #25

## Test plan
- [x] Red: test for missing notes fails before schema change
- [x] Green: all 110 tests pass with 100% coverage after change
- [x] `npm run typecheck` passes
- [x] `npm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)