### PR TITLE
fix: externalize hardcoded deploy config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  ECR_REGISTRY: 585768170262.dkr.ecr.us-west-2.amazonaws.com
   ECR_REPOSITORY: recipe-extraction-agent
 
 permissions:
@@ -32,6 +31,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Get AWS Account ID
+        id: account
+        run: echo "id=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_OUTPUT"
+
       - name: Login to Amazon ECR
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
@@ -46,12 +49,15 @@ jobs:
           push: true
           platforms: linux/arm64
           tags: |
-            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
-            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:sha-${{ github.sha }}
+            ${{ steps.account.outputs.id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPOSITORY }}:latest
+            ${{ steps.account.outputs.id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/${{ env.ECR_REPOSITORY }}:sha-${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Update AgentCore runtime
+        env:
+          ECR_REGISTRY: ${{ steps.account.outputs.id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+          ACCOUNT_ID: ${{ steps.account.outputs.id }}
         run: |
           aws bedrock-agentcore-control update-agent-runtime \
             --agent-runtime-id "${{ secrets.AGENTCORE_RUNTIME_ID }}" \
@@ -59,7 +65,7 @@ jobs:
             --role-arn "${{ secrets.AGENTCORE_ROLE_ARN }}" \
             --network-configuration '{"networkMode":"PUBLIC"}' \
             --protocol-configuration '{"serverProtocol":"HTTP"}' \
-            --environment-variables "{\"AWS_REGION\":\"${AWS_REGION}\",\"AWS_ACCOUNT_ID\":\"585768170262\",\"BEDROCK_AGENT_ID\":\"${{ secrets.AGENTCORE_RUNTIME_ID }}\",\"PRISMA_AIRS_PROFILE_NAME\":\"Recipe Extractor AWS Agent\"}" \
+            --environment-variables "{\"AWS_REGION\":\"${AWS_REGION}\",\"AWS_ACCOUNT_ID\":\"${ACCOUNT_ID}\",\"BEDROCK_AGENT_ID\":\"${{ secrets.AGENTCORE_RUNTIME_ID }}\",\"PRISMA_AIRS_PROFILE_NAME\":\"${{ secrets.PRISMA_AIRS_PROFILE_NAME }}\"}" \
             --region "${AWS_REGION}"
 
       - name: Wait for READY status

--- a/docs/deployment-guide/08-ci-cd-with-github-actions.md
+++ b/docs/deployment-guide/08-ci-cd-with-github-actions.md
@@ -218,13 +218,14 @@ Set GitHub repo secrets:
 
 ## GitHub Secrets
 
-Three secrets are needed in your repository:
+Four secrets are needed in your repository:
 
 | Secret | Value | Purpose |
 |---|---|---|
 | `AWS_ROLE_ARN` | `arn:aws:iam::...:role/github-actions-recipe-agent` | OIDC role for CI/CD |
 | `AGENTCORE_RUNTIME_ID` | Runtime ID from first deploy | Target runtime to update |
 | `AGENTCORE_ROLE_ARN` | `arn:aws:iam::...:role/BedrockAgentCoreRecipeAgent` | Execution role passed to runtime |
+| `PRISMA_AIRS_PROFILE_NAME` | AIRS security profile name | Prisma AIRS profile for prompt/response scanning |
 
 Set them with the `gh` CLI:
 
@@ -232,6 +233,7 @@ Set them with the `gh` CLI:
 gh secret set AWS_ROLE_ARN -b "arn:aws:iam::123456789012:role/github-actions-recipe-agent"
 gh secret set AGENTCORE_RUNTIME_ID -b "your-runtime-id"
 gh secret set AGENTCORE_ROLE_ARN -b "arn:aws:iam::123456789012:role/BedrockAgentCoreRecipeAgent"
+gh secret set PRISMA_AIRS_PROFILE_NAME -b "your-airs-profile-name"
 ```
 
 ## Deploy Workflow

--- a/scripts/setup-github-iam.sh
+++ b/scripts/setup-github-iam.sh
@@ -9,7 +9,10 @@ set -euo pipefail
 #   - ECR repository "recipe-extraction-agent" already exists
 #
 # Usage:
-#   scripts/setup-github-iam.sh
+#   AGENTCORE_RUNTIME_ID=<runtime-id> scripts/setup-github-iam.sh
+#
+# Required env vars:
+#   AGENTCORE_RUNTIME_ID    AgentCore runtime ID from first deploy
 ###############################################################################
 
 REGION="${AWS_REGION:-us-west-2}"
@@ -17,7 +20,12 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 ROLE_NAME="github-actions-recipe-agent"
 REPO="cdot65/aws-bedrock-agentcore-typescript-example"
 ECR_REPO="recipe-extraction-agent"
-RUNTIME_ID="${AGENTCORE_RUNTIME_ID:-recipe_extraction_agent-wkubdE7YBy}"
+
+if [[ -z "${AGENTCORE_RUNTIME_ID:-}" ]]; then
+  echo "ERROR: AGENTCORE_RUNTIME_ID env var required" >&2
+  exit 1
+fi
+RUNTIME_ID="${AGENTCORE_RUNTIME_ID}"
 
 echo "==> Creating GitHub Actions role: ${ROLE_NAME}"
 


### PR DESCRIPTION
## Summary
- Remove hardcoded AWS account ID (`585768170262`) from `deploy.yml` — now uses dynamic `aws sts get-caller-identity` lookup
- Remove hardcoded runtime ID fallback from `setup-github-iam.sh` — now requires `AGENTCORE_RUNTIME_ID` env var
- Externalize `PRISMA_AIRS_PROFILE_NAME` to GitHub secret in deploy workflow
- Update CI/CD docs (Part 8) with new secret

Closes #22, closes #23, closes #24

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run check` passes
- [x] `npm test` passes (110 tests)
- [ ] CI workflow passes
- [ ] After merge, set `PRISMA_AIRS_PROFILE_NAME` GitHub secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)