### PR TITLE
docs: update CLAUDE.md structure + Part 3 simplification notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ TypeScript agent built on the [bedrock-agentcore SDK](https://github.com/aws/bed
 ```
 src/
   app.ts          Agent logic, extractJson, extractUrl, processHandler, AIRS scanning
-  main.ts         Entry point (imports app, calls app.run())
+  main.ts         Bootstrap (Secrets Manager fetch) → dynamic import app → app.run()
   lib/
     cloudwatch-stream.ts  CloudWatch Logs streaming (createCloudWatchStream, createTeeStream)
   schemas/
@@ -21,11 +21,17 @@ src/
 tests/
   unit/           Schema, extractJson, fetch-url, cloudwatch-stream tests
   integration/    processHandler tests (mocked Agent + BedrockAgentCoreApp)
+scripts/
+  deploy.sh             First deploy + update AgentCore runtime
+  setup-github-iam.sh   Create IAM role for GitHub Actions OIDC
+docs/
+  deployment-guide/     9-part MkDocs deployment guide (Parts 01–09)
 .githooks/
   pre-commit      Runs typecheck → lint → test
 .github/
   workflows/
     ci.yml        GitHub Actions CI on PR/push to main
+    deploy.yml    Build → ECR push → AgentCore update on push to main
 ```
 
 ## Architecture Pattern

--- a/docs/deployment-guide/03-security-with-prisma-airs.md
+++ b/docs/deployment-guide/03-security-with-prisma-airs.md
@@ -187,6 +187,7 @@ export const processHandler = async (request, context) => {
         { sessionId: context.sessionId, metadata },
       );
     } catch (err) {
+      // Simplified — actual code includes scanErrorFields(err) and durationMs
       context.log.error({ err }, "AIRS prompt scan failed, proceeding unscanned");
     }
 
@@ -212,6 +213,7 @@ export const processHandler = async (request, context) => {
         { sessionId: context.sessionId, metadata: buildMetadata() },
       );
     } catch (err) {
+      // Simplified — actual code includes scanErrorFields(err) and durationMs
       context.log.error({ err }, "AIRS response scan failed, proceeding unscanned");
     }
 


### PR DESCRIPTION
## Summary
- Add `scripts/`, `docs/`, `deploy.yml` to CLAUDE.md project structure
- Update `main.ts` description to mention Secrets Manager bootstrap
- Add clarifying comments to simplified AIRS catch blocks in Part 3 docs

Closes #26, closes #27

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run check` passes
- [x] `npm test` passes (110 tests)
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)