### PR TITLE
feat: add GitHub Pages site with MkDocs Material

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/mkdocs-deploy.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install MkDocs
+        run: pip install mkdocs mkdocs-material
+
+      - name: Build docs
+        run: mkdocs build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 .env
 review-*/
 review-report-*.md
+site/

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,164 @@
+# Architecture Overview
+
+## System Diagram
+
+```mermaid
+graph TB
+    Client([Client / curl])
+
+    subgraph AgentCore["BedrockAgentCoreApp (Fastify :8080)"]
+        Ping["GET /ping"]
+        Invoke["POST /invocations"]
+    end
+
+    subgraph Security["Prisma AIRS AI Runtime Security"]
+        PromptScan["Prompt Scan<br/>(pre-LLM)"]
+        ResponseScan["Response Scan<br/>(post-LLM)"]
+    end
+
+    subgraph StrandsAgent["Strands Agent"]
+        Model["BedrockModel<br/>Claude Haiku 4.5"]
+        SystemPrompt["System Prompt<br/>(extraction rules)"]
+        FetchTool["fetch_url tool"]
+    end
+
+    subgraph Processing["Response Processing"]
+        ExtractJSON["extractJson()<br/>parse LLM text output"]
+        ZodValidation["RecipeSchema.parse()<br/>Zod v4 validation"]
+    end
+
+    subgraph FetchToolInternals["fetch_url internals"]
+        HTTPFetch["Node fetch()"]
+        LinkedOM["linkedom<br/>HTML parser"]
+        JSONLD["JSON-LD extractor<br/>schema.org/Recipe"]
+        StripHTML["Strip nav, header,<br/>footer, scripts"]
+    end
+
+    ExternalSite[(Recipe Website)]
+    Bedrock[(Amazon Bedrock<br/>us-west-2)]
+    AIRS[(Prisma AIRS API<br/>aisecurity.paloaltonetworks.com)]
+
+    Client -->|"POST {url}"| Invoke
+    Client -->|health check| Ping
+    Invoke --> PromptScan
+    PromptScan <-->|scan prompt| AIRS
+    PromptScan -->|allow| StrandsAgent
+    PromptScan -.->|block| Client
+    Model <-->|Converse API| Bedrock
+    Model -->|tool_use| FetchTool
+    FetchTool --> HTTPFetch
+    HTTPFetch -->|GET| ExternalSite
+    ExternalSite -->|HTML| LinkedOM
+    LinkedOM --> JSONLD
+    LinkedOM --> StripHTML
+    StripHTML -->|"text + jsonLd"| Model
+    JSONLD -->|"text + jsonLd"| Model
+    Model -->|JSON text| ExtractJSON
+    ExtractJSON --> ZodValidation
+    ZodValidation --> ResponseScan
+    ResponseScan <-->|scan response| AIRS
+    ResponseScan -->|allow| Client
+    ResponseScan -.->|block| Client
+
+    style AgentCore fill:#1a1a2e,stroke:#e94560,color:#fff
+    style Security fill:#2d1b36,stroke:#e94560,color:#fff
+    style StrandsAgent fill:#16213e,stroke:#0f3460,color:#fff
+    style Processing fill:#0f3460,stroke:#533483,color:#fff
+    style FetchToolInternals fill:#1a1a2e,stroke:#533483,color:#fff
+```
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant App as BedrockAgentCoreApp
+    participant AIRS as Prisma AIRS API
+    participant A as Strands Agent
+    participant B as Amazon Bedrock
+    participant T as fetch_url Tool
+    participant W as Recipe Website
+
+    C->>+App: POST /invocations<br/>{"url": "https://..."}
+    Note over App: Validate request via Zod<br/>Extract sessionId from header
+
+    rect rgb(45, 27, 54)
+        Note over App,AIRS: Pre-LLM Security Scan
+        App->>+AIRS: scanPrompt(prompt, sessionId)
+        AIRS-->>-App: {action: "allow" | "block"}
+    end
+
+    alt AIRS blocks prompt
+        App-->>C: 200 {error: "blocked", category, scan_id}
+    else AIRS allows prompt
+        App->>+A: agent.invoke("Extract recipe from URL")
+
+        A->>+B: Converse API<br/>(system prompt + user message)
+        B-->>-A: tool_use: fetch_url({url})
+
+        A->>+T: fetch_url({url})
+        T->>+W: GET https://...
+        W-->>-T: HTML response
+
+        Note over T: Parse HTML with linkedom
+        Note over T: Extract JSON-LD (schema.org/Recipe)
+        Note over T: Strip script, style, nav, header, footer
+        Note over T: Collapse whitespace, truncate at 30k chars
+
+        T-->>-A: {text, jsonLd}
+
+        A->>+B: Converse API<br/>(tool result with text + jsonLd)
+        B-->>-A: Recipe JSON as text response
+
+        A-->>-App: AgentResult
+
+        Note over App: extractJson() — parse raw text,<br/>code block, or brace extraction
+        Note over App: RecipeSchema.parse() — Zod validation
+
+        rect rgb(45, 27, 54)
+            Note over App,AIRS: Post-LLM Security Scan
+            App->>+AIRS: scanResponse(recipeJSON, prompt, sessionId)
+            AIRS-->>-App: {action: "allow" | "block"}
+        end
+
+        alt AIRS blocks response
+            App-->>C: 200 {error: "blocked", category, scan_id}
+        else AIRS allows response
+            App-->>-C: 200 OK<br/>typed Recipe JSON
+        end
+    end
+```
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|---|---|
+| **Prisma AIRS pre+post scan** | Scans inbound prompt for injection/malicious URLs and outbound response for DLP/toxic content |
+| **Fail-open on AIRS misconfiguration** | If API key missing, agent operates normally — no hard dependency on security service |
+| **Non-streaming handler** | Returns single JSON object — structured data doesn't benefit from SSE streaming |
+| **`extractJson()` fallback chain** | LLM may wrap JSON in markdown code blocks; tries direct parse, code block regex, then brace extraction |
+| **JSON-LD extraction** | Many recipe sites embed `schema.org/Recipe` structured data — improves accuracy |
+| **linkedom over jsdom** | ~200KB vs ~70MB; sufficient for text extraction and DOM traversal |
+| **Claude Haiku 4.5** | Fast, cheap, accurate for structured extraction — ~5-9s per request |
+| **temperature: 0** | Deterministic output for consistent JSON formatting |
+
+## Project Structure
+
+```
+src/
+  app.ts                 Agent logic, extractJson, processHandler, AIRS scanning
+  main.ts                Bootstrap (Secrets Manager fetch) → import app → app.run()
+  lib/
+    cloudwatch-stream.ts Custom CloudWatch log stream
+  schemas/
+    recipe.ts            Zod schemas for Recipe and Ingredient
+  tools/
+    fetch-url.ts         Custom tool: fetch URL, strip HTML, extract JSON-LD
+tests/
+  unit/                  Schema, extractJson, fetch-url, cloudwatch-stream tests
+  integration/           processHandler tests (mocked Agent + BedrockAgentCoreApp)
+scripts/
+  deploy.sh              First deploy + update AgentCore runtime
+  setup-github-iam.sh    Create IAM role for GitHub Actions OIDC
+  setup-secrets.sh       Store AIRS API key in Secrets Manager
+```

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,0 +1,179 @@
+/* ── Deep Purple / Amber overrides ────────────────────────────────── */
+
+:root {
+  --md-admonition-icon--tip: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>');
+}
+
+/* ── Typography & Readability ─────────────────────────────────────── */
+
+.md-grid {
+  max-width: 1200px;
+}
+
+.md-typeset {
+  font-size: 0.82rem;
+  line-height: 1.8;
+}
+
+.md-typeset p {
+  margin-bottom: 1em;
+}
+
+.md-typeset h1 {
+  font-weight: 700;
+  margin-top: 0;
+  margin-bottom: 0.8em;
+  letter-spacing: -0.02em;
+}
+
+.md-typeset h2 {
+  font-weight: 600;
+  margin-top: 2em;
+  margin-bottom: 0.6em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset h3 {
+  font-weight: 600;
+  margin-top: 1.6em;
+  margin-bottom: 0.4em;
+}
+
+/* ── Hero Section (Home Page) ─────────────────────────────────────── */
+
+.hero {
+  text-align: center;
+  padding: 2rem 0 1rem;
+}
+
+.hero h1 {
+  font-size: 2.4rem;
+  margin-bottom: 0.2em;
+  border-bottom: none;
+}
+
+.hero p:first-of-type {
+  font-size: 1.15rem;
+  color: var(--md-default-fg-color--light);
+  margin-bottom: 1.2em;
+}
+
+.hero-logo {
+  width: 120px;
+  height: 120px;
+  margin-bottom: 0.5rem;
+  filter: drop-shadow(0 4px 12px rgba(94, 53, 177, 0.25));
+}
+
+[data-md-color-scheme='slate'] .hero-logo {
+  filter: drop-shadow(0 4px 12px rgba(126, 87, 194, 0.4));
+}
+
+/* ── Admonition accent colors ─────────────────────────────────────── */
+
+.md-typeset .admonition.tip,
+.md-typeset details.tip {
+  border-color: #ffb300;
+}
+
+.md-typeset .tip > .admonition-title,
+.md-typeset .tip > summary {
+  background-color: rgba(255, 179, 0, 0.1);
+}
+
+.md-typeset .admonition.info,
+.md-typeset details.info {
+  border-color: #7e57c2;
+}
+
+.md-typeset .info > .admonition-title,
+.md-typeset .info > summary {
+  background-color: rgba(126, 87, 194, 0.1);
+}
+
+/* ── Tables ───────────────────────────────────────────────────────── */
+
+.md-typeset table:not([class]) th {
+  background-color: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+  font-weight: 600;
+}
+
+[data-md-color-scheme='slate'] .md-typeset table:not([class]) th {
+  background-color: rgba(126, 87, 194, 0.3);
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset table:not([class]) tbody tr:hover {
+  background-color: rgba(126, 87, 194, 0.04);
+}
+
+/* ── Code blocks ──────────────────────────────────────────────────── */
+
+.md-typeset code {
+  border-radius: 4px;
+  font-size: 0.82em;
+}
+
+.md-typeset pre > code {
+  line-height: 1.6;
+}
+
+/* ── Mermaid diagrams ─────────────────────────────────────────────── */
+
+.md-typeset .mermaid {
+  margin: 1.5em 0;
+  text-align: center;
+}
+
+/* ── Navigation ───────────────────────────────────────────────────── */
+
+@media screen and (min-width: 76.25em) {
+  .md-nav--lifted > .md-nav__list > .md-nav__item--active > .md-nav__link {
+    font-weight: 600;
+  }
+}
+
+/* ── Footer ───────────────────────────────────────────────────────── */
+
+.md-footer-meta__inner {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+/* ── Badges ───────────────────────────────────────────────────────── */
+
+.md-typeset img[alt='CI'],
+.md-typeset img[alt='License: MIT'],
+.md-typeset img[alt='Node 20+'],
+.md-typeset img[alt='TypeScript'] {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+/* ── Content tabs accent ──────────────────────────────────────────── */
+
+.md-typeset .tabbed-labels > label:hover {
+  color: var(--md-accent-fg-color);
+}
+
+/* ── Lists ────────────────────────────────────────────────────────── */
+
+.md-typeset ul,
+.md-typeset ol {
+  margin-bottom: 1em;
+}
+
+.md-typeset li {
+  margin-bottom: 0.3em;
+}
+
+/* ── Horizontal rules ─────────────────────────────────────────────── */
+
+.md-typeset hr {
+  margin: 2em 0;
+  border-color: var(--md-default-fg-color--lightest);
+}

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,44 @@
+# Configuration
+
+All configuration is via environment variables. Copy `.env.example` to `.env` for local development.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AWS_REGION` | `us-west-2` | AWS region for Bedrock and CloudWatch |
+| `PANW_AI_SEC_API_KEY` | — | Prisma AIRS API key (enables security scanning) |
+| `PRISMA_AIRS_PROFILE_NAME` | — | AIRS security profile name (required with API key) |
+| `BEDROCK_AGENT_ID` | — | Enables CloudWatch log streaming when set |
+| `AWS_ACCOUNT_ID` | — | Used in AIRS agent metadata |
+
+## Secrets Manager
+
+In production (when `BEDROCK_AGENT_ID` is set), `src/main.ts` attempts to fetch the AIRS API key from AWS Secrets Manager before falling back to the environment variable:
+
+```
+Secret ID: recipe-agent/prisma-airs-api-key
+```
+
+This avoids storing the API key in the AgentCore runtime environment variables. See [AWS Infrastructure Setup](../deployment-guide/06-aws-infrastructure-setup.md) for the Secrets Manager IAM policy.
+
+## AIRS Security Scanning
+
+Both `PANW_AI_SEC_API_KEY` and `PRISMA_AIRS_PROFILE_NAME` must be set to enable scanning. If either is missing, the agent operates normally without security checks (fail-open).
+
+When enabled, every request passes through two checkpoints:
+
+1. **Pre-scan** — prompt checked for injection, malicious URLs, toxic content
+2. **Post-scan** — response JSON checked for DLP violations, malicious content
+
+See [Security with Prisma AIRS](../deployment-guide/03-security-with-prisma-airs.md) for details.
+
+## CloudWatch Logging
+
+Set `BEDROCK_AGENT_ID` to enable structured JSON logging to CloudWatch. The log group is:
+
+```
+/aws/bedrock/agentcore/recipe-extraction-agent
+```
+
+Without this variable, logs go to stdout only. See [Observability](../deployment-guide/04-observability-cloudwatch-logs.md) for the full logging architecture.

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -1,0 +1,32 @@
+# Prerequisites
+
+## Required
+
+| Requirement | Details |
+|---|---|
+| **Node.js** | v20 or later ([download](https://nodejs.org/)) |
+| **AWS Account** | With Bedrock access in `us-west-2` |
+| **AWS CLI** | v2, configured with credentials (`aws configure`) |
+| **Model Access** | `us.anthropic.claude-haiku-4-5-20251001-v1:0` enabled in Bedrock |
+
+## Optional
+
+| Requirement | Details |
+|---|---|
+| **Docker** | For building the container image (ARM64/Graviton) |
+| **GitHub CLI (`gh`)** | For CI/CD setup and GitHub Actions OIDC |
+| **Prisma AIRS API Key** | For AI security scanning ([docs](https://docs.paloaltonetworks.com/prisma/prisma-cloud/prisma-cloud-admin/prisma-airs)) |
+
+## Verify Setup
+
+```bash
+node --version        # v20+
+aws sts get-caller-identity   # confirms credentials
+aws bedrock list-foundation-models \
+  --region us-west-2 \
+  --query "modelSummaries[?modelId=='anthropic.claude-haiku-4-5-20251001-v1:0'].modelId" \
+  --output text       # confirms model access
+```
+
+!!! tip "Model access"
+    If the model query returns empty, enable Claude Haiku 4.5 in the [Bedrock console](https://console.aws.amazon.com/bedrock/home?region=us-west-2#/modelaccess) under **Model access**.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,61 @@
+# Quick Start
+
+## 1. Install
+
+```bash
+git clone https://github.com/cdot65/aws-bedrock-agentcore-typescript-example.git
+cd aws-bedrock-agentcore-typescript-example
+npm install
+```
+
+## 2. Configure
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` — at minimum set `AWS_REGION` (defaults to `us-west-2`). AIRS variables are optional.
+
+## 3. Run
+
+```bash
+npm run dev
+```
+
+## 4. Test
+
+Health check:
+
+```bash
+curl http://localhost:8080/ping
+```
+
+Extract a recipe:
+
+```bash
+curl -X POST http://localhost:8080/invocations \
+  -H 'Content-Type: application/json' \
+  -H 'x-amzn-bedrock-agentcore-runtime-session-id: test-session-1' \
+  -d '{"url": "https://pinchofyum.com/chicken-wontons-in-spicy-chili-sauce"}'
+```
+
+The agent fetches the page, passes it to Claude Haiku 4.5, and returns a structured `Recipe` JSON object.
+
+!!! info "Alternative request format"
+    You can also send a natural language prompt containing a URL:
+
+    ```bash
+    curl -X POST http://localhost:8080/invocations \
+      -H 'Content-Type: application/json' \
+      -H 'x-amzn-bedrock-agentcore-runtime-session-id: test-session-1' \
+      -d '{"prompt": "Extract the recipe from https://pinchofyum.com/chicken-wontons-in-spicy-chili-sauce"}'
+    ```
+
+## 5. Run Tests
+
+```bash
+npm test                   # 110 tests
+npm run test:coverage      # with 100% coverage enforcement
+npm run typecheck          # tsc --noEmit
+npm run check              # biome lint + format
+```

--- a/docs/images/logo.svg
+++ b/docs/images/logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Document/recipe page -->
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+  <polyline points="14 2 14 8 20 8"/>
+  <!-- Extraction lines -->
+  <line x1="8" y1="13" x2="16" y2="13"/>
+  <line x1="8" y1="17" x2="12" y2="17"/>
+  <!-- Sparkle / AI indicator -->
+  <circle cx="17" cy="17" r="0.5" fill="#ffffff" stroke="none"/>
+  <path d="M17 14.5v1m0 3v1m-1.75-1.75h1m3 0h1" stroke-width="1"/>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,116 @@
+---
+title: Home
+---
+
+<div class="hero" markdown>
+
+![Recipe Extraction Agent Logo](images/logo.svg){ .hero-logo }
+
+# Recipe Extraction Agent
+
+**TypeScript agent on AWS Bedrock AgentCore**
+
+[![CI](https://github.com/cdot65/aws-bedrock-agentcore-typescript-example/actions/workflows/ci.yml/badge.svg)](https://github.com/cdot65/aws-bedrock-agentcore-typescript-example/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Node 20+](https://img.shields.io/badge/node-%3E%3D20-brightgreen.svg)](https://nodejs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6.svg)](https://www.typescriptlang.org/)
+
+</div>
+
+---
+
+Give it a URL, get back a strongly-typed `Recipe` JSON object. Built on [Bedrock AgentCore](https://github.com/aws/bedrock-agentcore-sdk-typescript) + [Strands Agents SDK](https://github.com/strands-agents/sdk-typescript), deployed to AWS with VM-level isolation and optional AI security scanning via Prisma AIRS.
+
+<div class="grid cards" markdown>
+
+- :material-web:{ .lg .middle } **URL to Structured Data**
+
+    ***
+
+    Point the agent at any recipe URL — it fetches the page, extracts JSON-LD and text, and returns a validated Recipe object with ingredients, steps, and notes.
+
+- :material-shield-check:{ .lg .middle } **AI Security Scanning**
+
+    ***
+
+    Optional Prisma AIRS integration scans inbound prompts and outbound responses for injection attacks, toxic content, and data leaks. Fail-open by default.
+
+- :material-cloud-outline:{ .lg .middle } **Bedrock AgentCore Runtime**
+
+    ***
+
+    Deployed as an ARM64 Docker container with VM-level isolation, auto-scaling, and a managed Fastify server on port 8080.
+
+- :material-eye-outline:{ .lg .middle } **Full Observability**
+
+    ***
+
+    Custom CloudWatch Logs streaming from inside the container — structured JSON logs for every request, agent invocation, and security scan.
+
+- :material-test-tube:{ .lg .middle } **100% Test Coverage**
+
+    ***
+
+    110 tests across 5 suites with enforced coverage thresholds. Pre-commit hooks and GitHub Actions CI gate every change.
+
+- :material-rocket-launch:{ .lg .middle } **Automated CI/CD**
+
+    ***
+
+    GitHub Actions with OIDC auth — push to main builds the image, pushes to ECR, and updates the AgentCore runtime automatically.
+
+</div>
+
+---
+
+## Request Flow
+
+```mermaid
+flowchart LR
+    URL["POST /invocations<br/>{url}"] --> AIRS1["AIRS Pre-Scan"]
+    AIRS1 --> Agent["Strands Agent<br/>+ fetch_url tool"]
+    Agent --> Bedrock["Claude Haiku 4.5<br/>(Bedrock)"]
+    Bedrock --> Parse["extractJson()<br/>+ Zod validation"]
+    Parse --> AIRS2["AIRS Post-Scan"]
+    AIRS2 --> Recipe["Typed Recipe JSON"]
+```
+
+---
+
+## Get Started
+
+<div class="grid cards" markdown>
+
+- :material-download:{ .lg .middle } **Prerequisites**
+
+    ***
+
+    Node.js 20+, AWS credentials, and a Bedrock-enabled account.
+
+    [:octicons-arrow-right-24: Prerequisites](getting-started/prerequisites.md)
+
+- :material-play-circle:{ .lg .middle } **Quick Start**
+
+    ***
+
+    Install, configure, and extract your first recipe in 2 minutes.
+
+    [:octicons-arrow-right-24: Quick Start](getting-started/quick-start.md)
+
+- :material-cog:{ .lg .middle } **Configuration**
+
+    ***
+
+    Environment variables, AIRS setup, and CloudWatch logging.
+
+    [:octicons-arrow-right-24: Configuration](getting-started/configuration.md)
+
+- :material-book-open-variant:{ .lg .middle } **Architecture**
+
+    ***
+
+    System design, request flow diagrams, and key design decisions.
+
+    [:octicons-arrow-right-24: Architecture](architecture/overview.md)
+
+</div>

--- a/docs/reference/dependencies.md
+++ b/docs/reference/dependencies.md
@@ -1,0 +1,31 @@
+# Dependencies
+
+## Runtime
+
+| Package | Version | Purpose |
+|---|---|---|
+| `bedrock-agentcore` | ^0.2.0 | Runtime server (Fastify on :8080), request routing, SSE support |
+| `@strands-agents/sdk` | ^0.4.0 | Agent framework — Agent, BedrockModel, tool decorator |
+| `@cdot65/prisma-airs-sdk` | ^0.2.0 | Prisma AIRS AI Runtime Security — prompt/response scanning |
+| `zod` | ^4.1.12 | Request/response schema validation |
+| `linkedom` | ^0.18.0 | Lightweight HTML parser (~200KB vs jsdom's 70MB) |
+| `@aws-sdk/client-cloudwatch-logs` | ^3.1002.0 | CloudWatch Logs PutLogEvents for custom log streaming |
+| `@aws-sdk/client-secrets-manager` | ^3.998.0 | Fetch AIRS API key from Secrets Manager at bootstrap |
+
+## Development
+
+| Package | Version | Purpose |
+|---|---|---|
+| `vitest` | ^4.0.18 | Test framework (110 tests, 100% coverage enforced) |
+| `@vitest/coverage-v8` | ^4.0.18 | V8-based code coverage provider |
+| `@biomejs/biome` | ^2.4.4 | Linting + formatting (single tool, zero plugins) |
+| `typescript` | ^5.7.0 | Type checking (strict mode) |
+| `tsx` | ^4.0.0 | TypeScript execution for dev server |
+
+## Why These Choices
+
+**linkedom over jsdom** — The agent only needs text extraction and DOM traversal, not a full browser environment. linkedom is ~350x smaller and faster to install.
+
+**Zod v4** — Used for both the incoming request schema (validated by BedrockAgentCoreApp) and the outgoing Recipe schema (validated after LLM extraction). Provides runtime type safety at system boundaries.
+
+**Biome over ESLint + Prettier** — Single binary, zero config plugins, handles both linting and formatting. Faster than the ESLint + Prettier combination.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,51 @@
+# Environment Variables
+
+## Runtime Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `AWS_REGION` | No | `us-west-2` | AWS region for Bedrock, CloudWatch, and Secrets Manager |
+| `PANW_AI_SEC_API_KEY` | No | — | Prisma AIRS API key; enables security scanning when paired with profile name |
+| `PRISMA_AIRS_PROFILE_NAME` | No | — | AIRS security profile; required alongside API key |
+| `BEDROCK_AGENT_ID` | No | — | AgentCore runtime ID; enables CloudWatch log streaming |
+| `AWS_ACCOUNT_ID` | No | — | Populates AIRS agent metadata for Strata Cloud Manager discovery |
+| `BEDROCK_AGENT_VERSION` | No | `1` | Agent version in AIRS metadata |
+
+## Behavior Matrix
+
+| `PANW_AI_SEC_API_KEY` | `PRISMA_AIRS_PROFILE_NAME` | Security Scanning |
+|---|---|---|
+| Set | Set | Enabled (pre + post scan) |
+| Set | Missing | Disabled (fail-open) |
+| Missing | Set | Disabled (fail-open) |
+| Missing | Missing | Disabled (fail-open) |
+
+| `BEDROCK_AGENT_ID` | Logging |
+|---|---|
+| Set | stdout + CloudWatch Logs |
+| Missing | stdout only |
+
+## Secrets Manager
+
+When `PANW_AI_SEC_API_KEY` is not in the environment, `src/main.ts` attempts to fetch it from Secrets Manager:
+
+```
+Secret ID: recipe-agent/prisma-airs-api-key
+```
+
+This requires the execution role to have `secretsmanager:GetSecretValue` on that secret ARN.
+
+## `.env.example`
+
+```bash
+# AWS
+AWS_REGION=us-west-2
+
+# Prisma AIRS (optional — both required to enable scanning)
+PANW_AI_SEC_API_KEY=
+PRISMA_AIRS_PROFILE_NAME=
+
+# AgentCore metadata (set automatically in deployed runtime)
+BEDROCK_AGENT_ID=
+AWS_ACCOUNT_ID=
+```

--- a/docs/reference/response-schema.md
+++ b/docs/reference/response-schema.md
@@ -1,0 +1,88 @@
+# Response Schema
+
+The agent returns a validated `Recipe` object (or an error object on failure).
+
+## Recipe
+
+```json
+{
+  "title": "Chicken Wontons in Spicy Chili Sauce",
+  "ingredients": [
+    {
+      "quantity": 3,
+      "unit": "tablespoons",
+      "name": "sesame oil",
+      "description": "divided"
+    },
+    {
+      "quantity": 2,
+      "unit": "",
+      "name": "eggs",
+      "description": "beaten"
+    }
+  ],
+  "preparationSteps": [
+    "Slice shiitake mushrooms",
+    "Grate garlic clove"
+  ],
+  "cookingSteps": [
+    "Heat 1 tablespoon sesame oil in a large nonstick skillet over medium heat..."
+  ],
+  "notes": {
+    "servings": "4 servings",
+    "cookTime": "10 minutes",
+    "prepTime": "5 minutes",
+    "tips": ["Use mini chicken cilantro wontons for best results"]
+  }
+}
+```
+
+## Field Reference
+
+### Ingredient
+
+| Field | Type | Description |
+|---|---|---|
+| `quantity` | `number` | Numeric quantity (fractions converted: 1/2 → 0.5) |
+| `unit` | `string` | Measurement unit; empty string `""` for unitless (e.g. "2 eggs") |
+| `name` | `string` | Ingredient name |
+| `description` | `string` | Preparation notes; empty string `""` if none |
+
+### Recipe
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | `string` | Yes | Recipe title |
+| `ingredients` | `Ingredient[]` | Yes | List of ingredients |
+| `preparationSteps` | `string[]` | Yes | Steps without heat (chopping, mixing, marinating) |
+| `cookingSteps` | `string[]` | Yes | Steps involving heat or actual cooking |
+| `notes` | `object` | No | Optional metadata (see below) |
+
+### Notes
+
+All fields within `notes` are optional. The entire `notes` object may be omitted.
+
+| Field | Type | Description |
+|---|---|---|
+| `servings` | `string` | Serving count |
+| `cookTime` | `string` | Cooking duration |
+| `prepTime` | `string` | Preparation duration |
+| `tips` | `string[]` | Additional tips or variations |
+
+## Error Responses
+
+On failure, the agent returns an error object instead of a Recipe:
+
+```json
+{
+  "error": "bad_request",
+  "message": "No URL found in request. Provide {\"url\": \"...\"} or a prompt containing a URL."
+}
+```
+
+| Error Code | Cause |
+|---|---|
+| `bad_request` | No URL in request body |
+| `agent_error` | LLM invocation failed |
+| `parse_error` | Agent response couldn't be parsed as Recipe JSON |
+| `blocked` | Request or response blocked by Prisma AIRS |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,93 @@
+site_name: Recipe Extraction Agent
+site_url: https://cdot65.github.io/aws-bedrock-agentcore-typescript-example/
+site_description: TypeScript agent on Bedrock AgentCore — extract structured recipes from any URL
+repo_name: cdot65/aws-bedrock-agentcore-typescript-example
+repo_url: https://github.com/cdot65/aws-bedrock-agentcore-typescript-example
+
+theme:
+  name: material
+  logo: images/logo.svg
+  favicon: images/logo.svg
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.footer
+    - content.code.copy
+    - content.tabs.link
+    - search.suggest
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+extra_css:
+  - css/custom.css
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.mark
+  - pymdownx.critic
+  - pymdownx.keys
+  - attr_list
+  - md_in_html
+  - tables
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Prerequisites: getting-started/prerequisites.md
+      - Quick Start: getting-started/quick-start.md
+      - Configuration: getting-started/configuration.md
+  - Architecture:
+      - Overview: architecture/overview.md
+      - Agent Deep Dive: deployment-guide/02-agent-architecture-deep-dive.md
+  - Security:
+      - Prisma AIRS: deployment-guide/03-security-with-prisma-airs.md
+  - Deployment:
+      - Introduction: deployment-guide/01-introduction-and-prerequisites.md
+      - Docker Build: deployment-guide/05-docker-and-container-build.md
+      - AWS Infrastructure: deployment-guide/06-aws-infrastructure-setup.md
+      - Deploy to AgentCore: deployment-guide/07-deploying-to-agentcore.md
+      - CI/CD: deployment-guide/08-ci-cd-with-github-actions.md
+      - Teardown: deployment-guide/09-teardown.md
+  - Observability:
+      - CloudWatch Logs: deployment-guide/04-observability-cloudwatch-logs.md
+      - Troubleshooting: troubleshooting-agent-logging.md
+  - Reference:
+      - Environment Variables: reference/environment-variables.md
+      - Response Schema: reference/response-schema.md
+      - Dependencies: reference/dependencies.md


### PR DESCRIPTION
## Summary
- Add MkDocs Material site with deep purple/amber theme (matching prisma-airs-sdk and daystrom)
- New pages: Home (hero + feature cards + mermaid flow), Getting Started (3 pages), Architecture Overview, Reference (3 pages)
- Integrates existing `docs/deployment-guide/` parts 01-09 and troubleshooting guide into MkDocs nav
- GitHub Actions workflow deploys to Pages on push to main (docs/mkdocs.yml changes)
- Custom CSS with typography, hero section, admonitions, table hover, mermaid centering

## New files
- `mkdocs.yml` — site config and navigation
- `docs/index.md` — home page with hero, feature cards, request flow diagram
- `docs/getting-started/` — prerequisites, quick start, configuration
- `docs/architecture/overview.md` — system diagram, sequence diagram, design decisions
- `docs/reference/` — environment variables, response schema, dependencies
- `docs/css/custom.css` — deep purple/amber theme overrides
- `docs/images/logo.svg` — site logo
- `.github/workflows/mkdocs-deploy.yml` — build + deploy to GitHub Pages

## Test plan
- [x] `mkdocs build` succeeds locally
- [x] `npm run typecheck` passes
- [x] `npm run check` passes
- [x] `npm test` passes (110 tests)
- [ ] CI workflow passes
- [ ] After merge, enable GitHub Pages (Settings → Pages → Source: GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)