### PR TITLE
docs: add deployment-guide README with table of contents (#37)

### DIFF
--- a/docs/deployment-guide/README.md
+++ b/docs/deployment-guide/README.md
@@ -1,0 +1,17 @@
+# Deployment Guide
+
+A 9-part guide covering the full lifecycle of building, securing, and deploying the Recipe Agent to AWS Bedrock AgentCore.
+
+## Table of Contents
+
+1. [Introduction & Prerequisites](01-introduction-and-prerequisites.md)
+2. [Agent Architecture Deep Dive](02-agent-architecture-deep-dive.md)
+3. [Security with Prisma AIRS](03-security-with-prisma-airs.md)
+4. [Observability — CloudWatch Logs](04-observability-cloudwatch-logs.md)
+5. [Docker & Container Build](05-docker-and-container-build.md)
+6. [AWS Infrastructure Setup](06-aws-infrastructure-setup.md)
+7. [Deploying to AgentCore](07-deploying-to-agentcore.md)
+8. [CI/CD with GitHub Actions](08-ci-cd-with-github-actions.md)
+9. [Teardown](09-teardown.md)
+
+> For the full rendered guide, visit the [MkDocs site](https://cdot65.github.io/agentcore-recipe-agent/).


### PR DESCRIPTION
## Summary
- Add `docs/deployment-guide/README.md` with table of contents linking all 9 parts of the deployment guide
- Include pointer to MkDocs GitHub Pages site for the full rendered guide

## Changes
- New file: `docs/deployment-guide/README.md`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)