### PR TITLE
refactor: extract AIRS scanning to dedicated module (#36)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,16 +1,12 @@
-import {
-  AISecSDKException,
-  Content,
-  init,
-  Scanner,
-  type ScanResponse,
-} from "@cdot65/prisma-airs-sdk";
 import { Agent, type AgentResult, BedrockModel } from "@strands-agents/sdk";
 import { BedrockAgentCoreApp } from "bedrock-agentcore/runtime";
 import { z } from "zod";
+import { airsEnabled, postScan, preScan } from "./lib/airs-scanner.js";
 import { createCloudWatchStream, createTeeStream } from "./lib/cloudwatch-stream.js";
 import { type Recipe, RecipeSchema } from "./schemas/recipe.js";
 import { fetchUrlTool } from "./tools/fetch-url.js";
+
+export { airsEnabled } from "./lib/airs-scanner.js";
 
 export const SYSTEM_PROMPT = `You are a recipe extraction agent. When given a URL:
 
@@ -94,59 +90,6 @@ export function extractJson(text: string): unknown {
   throw new Error("Could not extract JSON from agent response");
 }
 
-// AIRS SDK initialization
-const airsApiKey = process.env.PANW_AI_SEC_API_KEY || "";
-const airsProfileName = process.env.PRISMA_AIRS_PROFILE_NAME || "";
-export const airsEnabled = Boolean(airsApiKey && airsProfileName);
-
-if (airsEnabled) {
-  init({ apiKey: airsApiKey });
-}
-
-const scanner = airsEnabled ? new Scanner() : null;
-
-function buildMetadata() {
-  const agentId = process.env.BEDROCK_AGENT_ID;
-  const region = process.env.AWS_REGION || "us-west-2";
-  const accountId = process.env.AWS_ACCOUNT_ID;
-
-  return {
-    app_name: "recipe-extraction-agent",
-    app_user: "anonymous",
-    ai_model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-    agent_meta: agentId
-      ? {
-          agent_id: agentId,
-          agent_version: process.env.BEDROCK_AGENT_VERSION || "1",
-          agent_arn: accountId
-            ? `arn:aws:bedrock:${region}:${accountId}:agent/${agentId}`
-            : undefined,
-        }
-      : undefined,
-  };
-}
-
-function scanResultFields(scan: ScanResponse) {
-  return {
-    action: scan.action,
-    category: scan.category,
-    scanId: scan.scan_id,
-    reportId: scan.report_id,
-    profileId: scan.profile_id,
-    profileName: scan.profile_name,
-    trId: scan.tr_id,
-    promptDetected: scan.prompt_detected,
-    responseDetected: scan.response_detected,
-  };
-}
-
-function scanErrorFields(err: unknown) {
-  if (err instanceof AISecSDKException) {
-    return { err: String(err), errorType: err.errorType };
-  }
-  return { err: String(err) };
-}
-
 export const processHandler = async (
   request: { url?: string; prompt?: string },
   context: {
@@ -176,45 +119,15 @@ export const processHandler = async (
 
   const prompt = `Extract the recipe from this URL: ${url}`;
 
-  context.log.info({ airsEnabled, airsProfileName: airsProfileName || null }, "AIRS SDK status");
+  context.log.info(
+    { airsEnabled, airsProfileName: process.env.PRISMA_AIRS_PROFILE_NAME || null },
+    "AIRS SDK status",
+  );
 
   // Pre-scan: check inbound prompt for threats
-  if (scanner) {
-    const metadata = buildMetadata();
-    context.log.info(
-      { promptLength: prompt.length, profileName: airsProfileName, metadata },
-      "AIRS prompt scan starting",
-    );
-    let promptScan: ScanResponse | undefined;
-    try {
-      promptScan = await scanner.syncScan(
-        { profile_name: airsProfileName },
-        new Content({ prompt }),
-        { sessionId: context.sessionId, metadata },
-      );
-      context.log.info(
-        { ...scanResultFields(promptScan), durationMs: Date.now() - start },
-        "AIRS prompt scan complete",
-      );
-    } catch (err) {
-      context.log.error(
-        { ...scanErrorFields(err), durationMs: Date.now() - start },
-        "AIRS prompt scan failed, proceeding unscanned",
-      );
-    }
-
-    if (promptScan?.action === "block") {
-      context.log.warn(
-        { category: promptScan.category, scanId: promptScan.scan_id },
-        "Request blocked by AIRS",
-      );
-      return {
-        error: "blocked",
-        message: "Request blocked by Prisma AIRS security.",
-        category: promptScan.category,
-        scan_id: promptScan.scan_id,
-      };
-    }
+  const preScanResult = await preScan(prompt, context.sessionId, context.log);
+  if (preScanResult.blocked && preScanResult.blockResponse) {
+    return preScanResult.blockResponse;
   }
 
   const agentStart = Date.now();
@@ -258,49 +171,14 @@ export const processHandler = async (
   );
 
   // Post-scan: check outbound response for threats
-  if (scanner) {
-    const responseBody = JSON.stringify(recipe);
-    const metadata = buildMetadata();
-    context.log.info(
-      {
-        promptLength: prompt.length,
-        responseLength: responseBody.length,
-        profileName: airsProfileName,
-        metadata,
-      },
-      "AIRS response scan starting",
-    );
-    let responseScan: ScanResponse | undefined;
-    const responseScanStart = Date.now();
-    try {
-      responseScan = await scanner.syncScan(
-        { profile_name: airsProfileName },
-        new Content({ prompt, response: responseBody }),
-        { sessionId: context.sessionId, metadata },
-      );
-      context.log.info(
-        { ...scanResultFields(responseScan), durationMs: Date.now() - responseScanStart },
-        "AIRS response scan complete",
-      );
-    } catch (err) {
-      context.log.error(
-        { ...scanErrorFields(err), durationMs: Date.now() - responseScanStart },
-        "AIRS response scan failed, proceeding unscanned",
-      );
-    }
-
-    if (responseScan?.action === "block") {
-      context.log.warn(
-        { category: responseScan.category, scanId: responseScan.scan_id },
-        "Response blocked by AIRS",
-      );
-      return {
-        error: "blocked",
-        message: "Response blocked by Prisma AIRS security.",
-        category: responseScan.category,
-        scan_id: responseScan.scan_id,
-      };
-    }
+  const postScanResult = await postScan(
+    prompt,
+    JSON.stringify(recipe),
+    context.sessionId,
+    context.log,
+  );
+  if (postScanResult.blocked && postScanResult.blockResponse) {
+    return postScanResult.blockResponse;
   }
 
   const totalDurationMs = Date.now() - start;

--- a/src/lib/airs-scanner.ts
+++ b/src/lib/airs-scanner.ts
@@ -1,0 +1,183 @@
+import {
+  AISecSDKException,
+  Content,
+  init,
+  Scanner,
+  type ScanResponse,
+} from "@cdot65/prisma-airs-sdk";
+
+export interface LogInterface {
+  info: (obj: unknown, msg: string) => void;
+  warn: (obj: unknown, msg: string) => void;
+  error: (obj: unknown, msg: string) => void;
+}
+
+export interface ScanResult {
+  blocked: boolean;
+  blockResponse?: { error: string; message: string; category?: string; scan_id?: string };
+}
+
+// AIRS SDK initialization
+const airsApiKey = process.env.PANW_AI_SEC_API_KEY || "";
+const airsProfileName = process.env.PRISMA_AIRS_PROFILE_NAME || "";
+export const airsEnabled = Boolean(airsApiKey && airsProfileName);
+
+if (airsEnabled) {
+  init({ apiKey: airsApiKey });
+}
+
+const scanner = airsEnabled ? new Scanner() : null;
+
+export function buildMetadata() {
+  const agentId = process.env.BEDROCK_AGENT_ID;
+  const region = process.env.AWS_REGION || "us-west-2";
+  const accountId = process.env.AWS_ACCOUNT_ID;
+
+  return {
+    app_name: "recipe-extraction-agent",
+    app_user: "anonymous",
+    ai_model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    agent_meta: agentId
+      ? {
+          agent_id: agentId,
+          agent_version: process.env.BEDROCK_AGENT_VERSION || "1",
+          agent_arn: accountId
+            ? `arn:aws:bedrock:${region}:${accountId}:agent/${agentId}`
+            : undefined,
+        }
+      : undefined,
+  };
+}
+
+export function scanResultFields(scan: ScanResponse) {
+  return {
+    action: scan.action,
+    category: scan.category,
+    scanId: scan.scan_id,
+    reportId: scan.report_id,
+    profileId: scan.profile_id,
+    profileName: scan.profile_name,
+    trId: scan.tr_id,
+    promptDetected: scan.prompt_detected,
+    responseDetected: scan.response_detected,
+  };
+}
+
+export function scanErrorFields(err: unknown) {
+  if (err instanceof AISecSDKException) {
+    return { err: String(err), errorType: err.errorType };
+  }
+  return { err: String(err) };
+}
+
+export async function preScan(
+  prompt: string,
+  sessionId: string,
+  log: LogInterface,
+): Promise<ScanResult> {
+  if (!scanner) {
+    return { blocked: false };
+  }
+
+  const start = Date.now();
+  const metadata = buildMetadata();
+  log.info(
+    { promptLength: prompt.length, profileName: airsProfileName, metadata },
+    "AIRS prompt scan starting",
+  );
+
+  let promptScan: ScanResponse | undefined;
+  try {
+    promptScan = await scanner.syncScan(
+      { profile_name: airsProfileName },
+      new Content({ prompt }),
+      { sessionId, metadata },
+    );
+    log.info(
+      { ...scanResultFields(promptScan), durationMs: Date.now() - start },
+      "AIRS prompt scan complete",
+    );
+  } catch (err) {
+    log.error(
+      { ...scanErrorFields(err), durationMs: Date.now() - start },
+      "AIRS prompt scan failed, proceeding unscanned",
+    );
+  }
+
+  if (promptScan?.action === "block") {
+    log.warn(
+      { category: promptScan.category, scanId: promptScan.scan_id },
+      "Request blocked by AIRS",
+    );
+    return {
+      blocked: true,
+      blockResponse: {
+        error: "blocked",
+        message: "Request blocked by Prisma AIRS security.",
+        category: promptScan.category,
+        scan_id: promptScan.scan_id,
+      },
+    };
+  }
+
+  return { blocked: false };
+}
+
+export async function postScan(
+  prompt: string,
+  responseBody: string,
+  sessionId: string,
+  log: LogInterface,
+): Promise<ScanResult> {
+  if (!scanner) {
+    return { blocked: false };
+  }
+
+  const metadata = buildMetadata();
+  log.info(
+    {
+      promptLength: prompt.length,
+      responseLength: responseBody.length,
+      profileName: airsProfileName,
+      metadata,
+    },
+    "AIRS response scan starting",
+  );
+
+  let responseScan: ScanResponse | undefined;
+  const responseScanStart = Date.now();
+  try {
+    responseScan = await scanner.syncScan(
+      { profile_name: airsProfileName },
+      new Content({ prompt, response: responseBody }),
+      { sessionId, metadata },
+    );
+    log.info(
+      { ...scanResultFields(responseScan), durationMs: Date.now() - responseScanStart },
+      "AIRS response scan complete",
+    );
+  } catch (err) {
+    log.error(
+      { ...scanErrorFields(err), durationMs: Date.now() - responseScanStart },
+      "AIRS response scan failed, proceeding unscanned",
+    );
+  }
+
+  if (responseScan?.action === "block") {
+    log.warn(
+      { category: responseScan.category, scanId: responseScan.scan_id },
+      "Response blocked by AIRS",
+    );
+    return {
+      blocked: true,
+      blockResponse: {
+        error: "blocked",
+        message: "Response blocked by Prisma AIRS security.",
+        category: responseScan.category,
+        scan_id: responseScan.scan_id,
+      },
+    };
+  }
+
+  return { blocked: false };
+}

--- a/tests/unit/lib/airs-scanner.test.ts
+++ b/tests/unit/lib/airs-scanner.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSyncScan, MockAISecSDKException } = vi.hoisted(() => {
+  class MockAISecSDKException extends Error {
+    name = "AISecSDKException";
+    constructor(
+      message: string,
+      public errorType?: string,
+    ) {
+      super(errorType ? `${errorType}:${message}` : message);
+    }
+  }
+  return {
+    mockSyncScan: vi.fn(),
+    MockAISecSDKException,
+  };
+});
+
+vi.mock("@cdot65/prisma-airs-sdk", () => ({
+  init: vi.fn(),
+  Scanner: class {
+    syncScan = mockSyncScan;
+  },
+  Content: class {
+    constructor(public opts: unknown) {}
+  },
+  AISecSDKException: MockAISecSDKException,
+}));
+
+function mockLog() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+const fullScanResponse = {
+  action: "allow",
+  category: "benign",
+  scan_id: "s1",
+  report_id: "r1",
+  profile_id: "prof-1",
+  profile_name: "test-profile",
+  tr_id: "tr-1",
+  prompt_detected: { injection: false },
+  response_detected: undefined,
+};
+
+describe("airs-scanner", () => {
+  beforeEach(() => {
+    mockSyncScan.mockReset();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("airsEnabled", () => {
+    it("is false when env vars are missing", async () => {
+      const { airsEnabled } = await import("../../../src/lib/airs-scanner.js");
+      expect(airsEnabled).toBe(false);
+    });
+
+    it("is true when both env vars are set", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+
+      const { airsEnabled } = await import("../../../src/lib/airs-scanner.js");
+      expect(airsEnabled).toBe(true);
+    });
+
+    it("is false when only API key is set", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+
+      const { airsEnabled } = await import("../../../src/lib/airs-scanner.js");
+      expect(airsEnabled).toBe(false);
+    });
+
+    it("is false when only profile name is set", async () => {
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+
+      const { airsEnabled } = await import("../../../src/lib/airs-scanner.js");
+      expect(airsEnabled).toBe(false);
+    });
+  });
+
+  describe("preScan", () => {
+    beforeEach(() => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+    });
+
+    it("returns non-blocked when scanner allows", async () => {
+      mockSyncScan.mockResolvedValueOnce(fullScanResponse);
+      const { preScan } = await import("../../../src/lib/airs-scanner.js");
+      const log = mockLog();
+
+      const result = await preScan("test prompt", "session-1", log);
+
+      expect(result).toEqual({ blocked: false });
+      expect(log.info).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "allow" }),
+        "AIRS prompt scan complete",
+      );
+    });
+
+    it("returns blocked response when scanner blocks", async () => {
+      mockSyncScan.mockResolvedValueOnce({
+        action: "block",
+        category: "injection",
+        scan_id: "s-blocked",
+      });
+      const { preScan } = await import("../../../src/lib/airs-scanner.js");
+      const log = mockLog();
+
+      const result = await preScan("test prompt", "session-1", log);
+
+      expect(result.blocked).toBe(true);
+      expect(result.blockResponse).toEqual({
+        error: "blocked",
+        message: "Request blocked by Prisma AIRS security.",
+        category: "injection",
+        scan_id: "s-blocked",
+      });
+    });
+
+    it("handles scanner errors gracefully", async () => {
+      mockSyncScan.mockRejectedValueOnce(new Error("AIRS timeout"));
+      const { preScan } = await import("../../../src/lib/airs-scanner.js");
+      const log = mockLog();
+
+      const result = await preScan("test prompt", "session-1", log);
+
+      expect(result).toEqual({ blocked: false });
+      expect(log.error).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.stringContaining("AIRS timeout") }),
+        "AIRS prompt scan failed, proceeding unscanned",
+      );
+    });
+
+    it("returns non-blocked when scanner is disabled", async () => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+      const { preScan } = await import("../../../src/lib/airs-scanner.js");
+      const log = mockLog();
+
+      const result = await preScan("test prompt", "session-1", log);
+
+      expect(result).toEqual({ blocked: false });
+      expect(mockSyncScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("postScan", () => {
+    beforeEach(() => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+    });
+
+    it("returns non-blocked when scanner allows", async () => {
+      mockSyncScan.mockResolvedValueOnce(fullScanResponse);
+      const { postScan } = await import("../../../src/lib/airs-scanner.js");
+      const log = mockLog();
+
+      const result = await postScan("test prompt", '{"recipe": true}', "session-1", log);
+
+      expect(result).toEqual({ blocked: false });
+      expect(log.info).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "allow" }),
+        "AIRS response scan complete",
+      );
+    });
+
+    it("returns blocked response when scanner blocks", async () => {
+      mockSyncScan.mockResolvedValueOnce({
+        action: "block",
+        category: "dlp",
+        scan_id: "s-resp-blocked",
+      });
+      const { postScan } = await import("../../../src/lib/airs-scanner.js");
+      const log = mockLog();
+
+      const result = await postScan("test prompt", '{"recipe": true}', "session-1", log);
+
+      expect(result.blocked).toBe(true);
+      expect(result.blockResponse).toEqual({
+        error: "blocked",
+        message: "Response blocked by Prisma AIRS security.",
+        category: "dlp",
+        scan_id: "s-resp-blocked",
+      });
+    });
+
+    it("handles scanner errors gracefully", async () => {
+      mockSyncScan.mockRejectedValueOnce(new Error("AIRS timeout"));
+      const { postScan } = await import("../../../src/lib/airs-scanner.js");
+      const log = mockLog();
+
+      const result = await postScan("test prompt", '{"recipe": true}', "session-1", log);
+
+      expect(result).toEqual({ blocked: false });
+      expect(log.error).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.stringContaining("AIRS timeout") }),
+        "AIRS response scan failed, proceeding unscanned",
+      );
+    });
+
+    it("returns non-blocked when scanner is disabled", async () => {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+      const { postScan } = await import("../../../src/lib/airs-scanner.js");
+      const log = mockLog();
+
+      const result = await postScan("test prompt", '{"recipe": true}', "session-1", log);
+
+      expect(result).toEqual({ blocked: false });
+      expect(mockSyncScan).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("buildMetadata", () => {
+    it("includes agent_meta when BEDROCK_AGENT_ID is set", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+      vi.stubEnv("BEDROCK_AGENT_ID", "agent-123");
+      vi.stubEnv("AWS_REGION", "us-east-1");
+      vi.stubEnv("AWS_ACCOUNT_ID", "111222333");
+      vi.stubEnv("BEDROCK_AGENT_VERSION", "3");
+
+      const { buildMetadata } = await import("../../../src/lib/airs-scanner.js");
+      const metadata = buildMetadata();
+
+      expect(metadata.agent_meta).toEqual({
+        agent_id: "agent-123",
+        agent_version: "3",
+        agent_arn: "arn:aws:bedrock:us-east-1:111222333:agent/agent-123",
+      });
+    });
+
+    it("omits agent_meta when BEDROCK_AGENT_ID is not set", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+
+      const { buildMetadata } = await import("../../../src/lib/airs-scanner.js");
+      const metadata = buildMetadata();
+
+      expect(metadata.agent_meta).toBeUndefined();
+    });
+
+    it("omits agent_arn when AWS_ACCOUNT_ID is not set", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+      vi.stubEnv("BEDROCK_AGENT_ID", "agent-456");
+
+      const { buildMetadata } = await import("../../../src/lib/airs-scanner.js");
+      const metadata = buildMetadata();
+
+      expect(metadata.agent_meta?.agent_arn).toBeUndefined();
+    });
+
+    it("defaults agent_version to 1", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+      vi.stubEnv("BEDROCK_AGENT_ID", "agent-456");
+
+      const { buildMetadata } = await import("../../../src/lib/airs-scanner.js");
+      const metadata = buildMetadata();
+
+      expect(metadata.agent_meta?.agent_version).toBe("1");
+    });
+
+    it("includes standard app fields", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+
+      const { buildMetadata } = await import("../../../src/lib/airs-scanner.js");
+      const metadata = buildMetadata();
+
+      expect(metadata.app_name).toBe("recipe-extraction-agent");
+      expect(metadata.app_user).toBe("anonymous");
+      expect(metadata.ai_model).toBe("us.anthropic.claude-haiku-4-5-20251001-v1:0");
+    });
+  });
+
+  describe("scanResultFields", () => {
+    it("maps ScanResponse fields correctly", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+
+      const { scanResultFields } = await import("../../../src/lib/airs-scanner.js");
+      const result = scanResultFields(fullScanResponse);
+
+      expect(result).toEqual({
+        action: "allow",
+        category: "benign",
+        scanId: "s1",
+        reportId: "r1",
+        profileId: "prof-1",
+        profileName: "test-profile",
+        trId: "tr-1",
+        promptDetected: { injection: false },
+        responseDetected: undefined,
+      });
+    });
+  });
+
+  describe("scanErrorFields", () => {
+    it("handles AISecSDKException with errorType", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+
+      const { scanErrorFields } = await import("../../../src/lib/airs-scanner.js");
+      const err = new MockAISecSDKException("API error 500", "AISEC_SERVER_SIDE_ERROR");
+      const result = scanErrorFields(err);
+
+      expect(result).toEqual({
+        err: expect.stringContaining("AISEC_SERVER_SIDE_ERROR"),
+        errorType: "AISEC_SERVER_SIDE_ERROR",
+      });
+    });
+
+    it("handles plain errors", async () => {
+      vi.stubEnv("PANW_AI_SEC_API_KEY", "test-key");
+      vi.stubEnv("PRISMA_AIRS_PROFILE_NAME", "test-profile");
+
+      const { scanErrorFields } = await import("../../../src/lib/airs-scanner.js");
+      const err = new Error("network failure");
+      const result = scanErrorFields(err);
+
+      expect(result).toEqual({ err: "Error: network failure" });
+      expect(result).not.toHaveProperty("errorType");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract all AIRS scanning logic from `src/app.ts` into `src/lib/airs-scanner.ts` (init, scanner, buildMetadata, scanResultFields, scanErrorFields, preScan, postScan)
- `app.ts` now calls `preScan()`/`postScan()` and re-exports `airsEnabled`; drops from 331 to 191 lines
- Add 20 unit tests in `tests/unit/lib/airs-scanner.test.ts` covering enabled/disabled, block/allow, error handling, metadata, and field mapping

## Changes

- **New**: `src/lib/airs-scanner.ts` — standalone AIRS scanning module with typed `ScanResult` interface
- **Modified**: `src/app.ts` — removed all AIRS SDK imports and inline scanning logic, replaced with `preScan`/`postScan` calls
- **New**: `tests/unit/lib/airs-scanner.test.ts` — 20 tests for the extracted module

All 130 tests pass with 100% coverage on statements, branches, functions, and lines.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)